### PR TITLE
Adding NEE to both Hogg and OHM 2nd stages

### DIFF
--- a/TraceAnalysis_ini/HOGG/HOGG_SecondStage.ini
+++ b/TraceAnalysis_ini/HOGG/HOGG_SecondStage.ini
@@ -10,6 +10,9 @@
 % 	- Added shiftMyData (adapted from Tzu-Yi Lu DSM site) to correct for daylight savings 60 min offset.
 % 	- For future: Apply 60 min offset from siteStart to 2021 Nov 7 3:00:00 in EddyPro processing 
 % 	  so raw files in database are also corrected.
+%
+% Oct 17, 2023 (Ted)
+%	- added NEE to align with YOUNG
 
 Site_name = 'Hogg Marsh'
 SiteID = 'HOGG'
@@ -411,6 +414,21 @@ searchPath = 'auto'
 	minMax = [-60,50]
 
 	Ameriflux_Variable = 'SC'
+	Ameriflux_DataType = 'AMF_BASE_HH'
+[End]
+
+[Trace]
+	variableName = 'NEE'
+
+	Evaluate = 'NEE = sum([FC,SC],2,''omitnan'');
+		    NEE(all(isnan(FC)&isnan(SC),2)) = NaN;
+			NEE = shiftMyData(clean_tv,NEE,datenum(2021,11,07,03,00,0),60);'
+	
+	title = 'net ecosystem exchange'
+	units = '\mu mol m^{-2} s^{-1}'
+	minMax = [-40,50]
+
+	Ameriflux_Variable = 'NEE'
 	Ameriflux_DataType = 'AMF_BASE_HH'
 [End]
 

--- a/TraceAnalysis_ini/OHM/OHM_SecondStage.ini
+++ b/TraceAnalysis_ini/OHM/OHM_SecondStage.ini
@@ -382,7 +382,7 @@ searchPath = 'auto'
 	variableName = 'NEE'
 
 	Evaluate = 'NEE = sum([FC,SC],2,''omitnan'');
-		    NEE(all(isnan(FC)&isnan(SC),2)) = NaN;
+		    NEE(all(isnan(FC)&isnan(SC),2)) = NaN;'
 	title = 'net ecosystem exchange'
 	units = '\mu mol m^{-2} s^{-1}'
 	minMax = [-40,50]

--- a/TraceAnalysis_ini/OHM/OHM_SecondStage.ini
+++ b/TraceAnalysis_ini/OHM/OHM_SecondStage.ini
@@ -7,8 +7,11 @@
 % Revisions:
 %
 % Oct 11, 2023 (Ted)
-%	Updated to remove YOUNG values as backups as OHM is not near YOUNG
-%	Removed all shiftMyData calls
+%	- Updated to remove YOUNG values as backups as OHM is not near YOUNG
+%	- Removed all shiftMyData calls
+%
+% Oct 17, 2023 (Ted)
+%	- added NEE following pattern in YOUNG/HOGG 2nd stages
 
 Site_name = 'Oak Hammond Marsh'
 SiteID = 'OHM'
@@ -372,6 +375,19 @@ searchPath = 'auto'
 	minMax = [-60,50]
 
 	Ameriflux_Variable = 'SC'
+	Ameriflux_DataType = 'AMF_BASE_HH'
+[End]
+
+[Trace]
+	variableName = 'NEE'
+
+	Evaluate = 'NEE = sum([FC,SC],2,''omitnan'');
+		    NEE(all(isnan(FC)&isnan(SC),2)) = NaN;
+	title = 'net ecosystem exchange'
+	units = '\mu mol m^{-2} s^{-1}'
+	minMax = [-40,50]
+
+	Ameriflux_Variable = 'NEE'
 	Ameriflux_DataType = 'AMF_BASE_HH'
 [End]
 


### PR DESCRIPTION
For some reason they were missing, so I used the trace chunk in the YOUNG 2nd stage as a pattern. Confirmed runs locally via fr_automated_cleaning for each site, 1st and 2nd stages