### PR TITLE
Fixing LW/SW calibration values for Young

### DIFF
--- a/TraceAnalysis_ini/YOUNG/YOUNG_FirstStage.ini
+++ b/TraceAnalysis_ini/YOUNG/YOUNG_FirstStage.ini
@@ -19,7 +19,20 @@
 %	for sea level vs site elevation pressure and there were some data irregularities
 %
 %	- after considerable discussion with Pascal, Zoran, Sara, updated SW/LW IN/OUT to account for when the correct calibration
-%	coeffs were loaded in the logger on site versus when they were incorrect
+%	coeffs were loaded in the logger on site versus when they were incorrect. Looks like the calibration values for upper vs lower sensor were 
+%   swapped by mistake between Nov 2021 and Sep 2022, later corrected by an update pushed by Licor with new calibration values. For reference,
+%   the values used for Nov 2021 - Sep 2022:
+%  		Long wave – sensitivity upper sensor: 12.17 µV/W/m2 [I believe this value and the one below were accidentally swapped in the logger]
+%  		Long wave – sensitivity lower sensor: 9.36 µV/W/m2
+%  		Short wave – sensitivity upper sensor: 13.48 µV/W/m2 [I believe this value and the one below were accidentally swapped in the logger]
+%  		Short wave – sensitivity lower sensor: 14.10 µV/W/m2
+%
+%   And for Sep 2022 - Dec 2023+ the values should be:
+%		Long wave – sensitivity upper sensor: 9.31 µV/W/m2
+%		Long wave – sensitivity lower sensor: 8.63 µV/W/m2
+%		Short wave – sensitivity upper sensor: 12.75 µV/W/m2
+%		Short wave – sensitivity lower sensor: 14.12 µV/W/m2
+%
 
 
 Site_name = 'Young Marsh'
@@ -290,7 +303,7 @@ Difference_GMT_to_local_time = 5 % hours
 	calibrationDates = ''
         %loggedCalibration = '[12.17 0 datenum(2021,1,1) datenum(2022,12,31); 12.17 0 datenum(2023,1,1) datenum(2999,1,1)]' 
         %currentCalibration = '[10.30 0 datenum(2021,1,1) datenum(2022,12,31); 11.41 0 datenum(2023,1,1) datenum(2999,1,1)]' % adjusted 2023-10-30, see comment at top
-		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 13.48 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
+		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 14.10 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
         currentCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 12.75 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]'
 	comments = 'Logger on site should have had correct values except between Nov 2021 and Sep 2022' %'Young was reading high relative to Hogg - adjusting calibration 2023-10-30' 
 	minMax = [-50,2000]
@@ -315,7 +328,7 @@ Difference_GMT_to_local_time = 5 % hours
 	calibrationDates = ''
         %loggedCalibration = '[9.36 0 datenum(2021,1,1) datenum(2999,1,1)]' 
         %currentCalibration = '[14.12 0 datenum(2021,1,1) datenum(2999,1,1)]' 
-		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 14.10 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
+		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 13.48 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
         currentCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 14.12 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]'
 	comments = 'Logger on site should have had correct values except between Nov 2021 and Sep 2022' 
 	minMax = [-50,1500]
@@ -340,7 +353,7 @@ Difference_GMT_to_local_time = 5 % hours
 	calibrationDates = ''
         %loggedCalibration = '[13.48 0 datenum(2021,1,1) datenum(2999,1,1)]' 
         %currentCalibration = '[9.31 0 datenum(2021,1,1) datenum(2999,1,1)]' 
-		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 12.17 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
+		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 9.36 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
         currentCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 9.31 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]'
 	comments = 'Logger on site should have had correct values except between Nov 2021 and Sep 2022' 
 	minMax = [50,800]
@@ -365,7 +378,7 @@ Difference_GMT_to_local_time = 5 % hours
 	calibrationDates = ''
         %loggedCalibration = '[14.1 0 datenum(2021,1,1) datenum(2999,1,1)]' 
         %currentCalibration = '[8.63 0 datenum(2021,1,1) datenum(2999,1,1)]' 
-		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 9.36 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
+		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 12.17 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]' 
         currentCalibration = '[1 0 datenum(2021,1,1) datenum(2021,11,19); 8.63 0 datenum(2021,11,20) datenum(2022,9,28); 1 0 datenum(2022,9,29) datenum(2999,1,1)]'
 	comments = 'Logger on site should have had correct values except between Nov 2021 and Sep 2022'
 	minMax = [0,800]

--- a/TraceAnalysis_ini/YOUNG/YOUNG_SecondStage.ini
+++ b/TraceAnalysis_ini/YOUNG/YOUNG_SecondStage.ini
@@ -104,7 +104,7 @@ searchPath = 'auto'
 	variableName = 'SW_IN_1_1_1'
 
 	Evaluate = 'SWIN_1_1_1 = shiftMyData(clean_tv,SWIN_1_1_1,datenum(2021,11,07,03,00,0),60);
-					SW_IN_1_1_1 = SWIN_1_1_1;' %calc_avg_trace(clean_tv,SWIN_1_1_1,Hogg_SWIN_1_1_1,-1);' %temp dropping Hogg as backup
+					SW_IN_1_1_1 = calc_avg_trace(clean_tv,SWIN_1_1_1,Hogg_SWIN_1_1_1,-1);' %Hogg as backup
 
 	title = 'incoming shortwave radiation by CNR4'
 	units = 'W/m^2'
@@ -126,7 +126,7 @@ searchPath = 'auto'
 	variableName = 'LW_IN_1_1_1'
 
 	Evaluate = 'LWIN_1_1_1 = shiftMyData(clean_tv,LWIN_1_1_1,datenum(2021,11,07,03,00,0),60);
-					LW_IN_1_1_1 = LWIN_1_1_1;' %calc_avg_trace(clean_tv,LWIN_1_1_1,Hogg_LWIN_1_1_1,-1);' %temp dropping Hogg as backup
+					LW_IN_1_1_1 = calc_avg_trace(clean_tv,LWIN_1_1_1,Hogg_LWIN_1_1_1,-1);' %Hogg as backup
 
 	title = 'incoming long wave radiation by CNR4'
 	units = 'W/m^2'


### PR DESCRIPTION
Looks like whomever did the logger onsite update accidentally confused the upper and lower sensors when they put in the values. Swapping them makes SWIN and LWIN look so much better for Nov 21 - Sep 22. Still waiting on input from Pascal to address data prior to Nov 2021.