### PR TITLE
Handling SWIN SWOUT RN and ALB for Young after calibration fixes

### DIFF
--- a/TraceAnalysis_ini/YOUNG/YOUNG_FirstStage.ini
+++ b/TraceAnalysis_ini/YOUNG/YOUNG_FirstStage.ini
@@ -34,6 +34,11 @@
 %		Short wave – sensitivity upper sensor: 12.75 µV/W/m2
 %		Short wave – sensitivity lower sensor: 14.12 µV/W/m2
 %
+%	Jan 11 2023 (Ted)
+%	- after discovering the calibration coefficients for SWIN may have been swapped around, we suspect SWOUT *could* have issues as well 
+%	in the same timeframe but as the calibration files from that timeframe are lost (daqm files) we cannot confirm
+%	- given the changes for SWIN we are going to calculate RN (netrad) and ALB in stage 2 from SWIN/OUT and LWIN/OUT
+%
 
 
 Site_name = 'Young Marsh'
@@ -331,7 +336,7 @@ Difference_GMT_to_local_time = 5 % hours
         %currentCalibration = '[14.12 0 datenum(2021,1,1) datenum(2999,1,1)]' 
 		loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2999,1,1)]' 
         currentCalibration = '[1 0 datenum(2021,1,1) datenum(2999,1,1)]'
-	comments = 'Logger on site likely has correct values' 
+	comments = 'Logger on site likely has correct values' % see comment in header
 	minMax = [-50,1500]
 	zeroPt = [-9999] 
 	
@@ -404,7 +409,7 @@ Difference_GMT_to_local_time = 5 % hours
 	calibrationDates = ''
         loggedCalibration = '' 
         currentCalibration = '' 
-	comments = '' 
+	comments = 'due to calibration changes we will be calculating netrad in stage 2, see header' 
 	minMax = [-200,2000]
 	zeroPt = [-9999] 
 	
@@ -427,7 +432,7 @@ Difference_GMT_to_local_time = 5 % hours
 	calibrationDates = ''
         loggedCalibration = '[1 0 datenum(2021,1,1) datenum(2999,1,1)]' 
         currentCalibration = '[100 0 datenum(2021,1,1) datenum(2999,1,1)]'
-	comments = 'ALB needs to be in % so multiplying by 100' 
+	comments = 'ALB needs to be in % so multiplying by 100. due to calibration changes we will be calculating ALB in stage 2, see header' 
 	minMax = [-10,110]
 	clamped_minMax = [0,100]
 	zeroPt = [-9999] 

--- a/TraceAnalysis_ini/YOUNG/YOUNG_SecondStage.ini
+++ b/TraceAnalysis_ini/YOUNG/YOUNG_SecondStage.ini
@@ -10,6 +10,12 @@
 % 	- Added shiftMyData (adapted from Tzu-Yi Lu DSM site) to correct for daylight savings 60 min offset.
 % 	- For future: Apply 60 min offset from siteStart to 2021 Nov 7 3:00:00 in EddyPro processing 
 % 	  so raw files in database are also corrected.
+%
+% Jan 11 2023 (Ted)
+%	- we changed the calibration values for SWIN in 2021 to correct for a mismatch in the logger, which means we need to calculate
+%	both RN_1_1_1 and ALB_1_1_1 here using the updated values for SWIN/OUT and LWIN/OUT
+%	- RN_1_1_1 aka NETRAD_1_1_1 is SW_IN - SW_OUT + LW_IN - LW_OUT per Monteith & Unsworth 2013, p. 75
+%	- as part of this update, I now replace negative values of SWOUT with NaN and for ALB anything outside 0-100 is set to NaN
 
 Site_name = 'Young Marsh'
 SiteID = 'YOUNG'
@@ -115,7 +121,8 @@ searchPath = 'auto'
 	variableName = 'SW_OUT_1_1_1'
 
 	Evaluate = 'SWOUT_1_1_1 = shiftMyData(clean_tv,SWOUT_1_1_1,datenum(2021,11,07,03,00,0),60);
-					SW_OUT_1_1_1 = SWOUT_1_1_1;'
+					SW_OUT_1_1_1 = SWOUT_1_1_1;
+					indBad = find(SW_OUT_1_1_1 < 0);SW_OUT_1_1_1(indBad) = NaN;' % remove negative values
 
 	title = 'reflected shortwave radiation by CNR4'
 	units = 'W/m^2'
@@ -158,7 +165,7 @@ searchPath = 'auto'
 	variableName = 'NETRAD_1_1_1'
 
 	Evaluate = 'RN_1_1_1 = shiftMyData(clean_tv,RN_1_1_1,datenum(2021,11,07,03,00,0),60);
-					NETRAD_1_1_1 = RN_1_1_1;'
+					NETRAD_1_1_1 = SW_IN_1_1_1 - SW_OUT_1_1_1 + LW_IN_1_1_1 - LW_OUT_1_1_1;' % see comment in header
 
 	title = 'net radiation by CNR4'
 	units = 'W/m^2'
@@ -168,9 +175,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'ALB_1_1_1'
 
-	Evaluate = 'ALB_1_1_1 = shiftMyData(clean_tv,ALB_1_1_1,datenum(2021,11,07,03,00,0),60);
-					ALB_1_1_1 = ALB_1_1_1;'
-
+	Evaluate = 'ALB_1_1_1 = 100 * SW_OUT_1_1_1./SW_IN_1_1_1;
+				indBad = find(ALB_1_1_1 < 0 | ALB_1_1_1 >100);ALB_1_1_1(indBad) = NaN;' % see comment in header. was shiftMyData(clean_tv,ALB_1_1_1,datenum(2021,11,07,03,00,0),60);
+					
 	title = 'albedo by CNR4'
 	units = '%'
 	minMax = [-10,110]


### PR DESCRIPTION
With the changes to SWIN's 1st stage for 2021 to deal with the calibration value mismatch, we need to calculate NETRAD and ALB using the radiation values directly rather than rely on what is coming from the logger on site. So, these are now calculated in the 2nd stage. I also do some filtering out of negative SWOUT and ALB to 0-100. NaNs are written instead of unphysical values. Comments in header cover the changes and any needed references.