### PR TITLE
Add air pressure flag trace for Hogg

### DIFF
--- a/TraceAnalysis_ini/HOGG/HOGG_FirstStage.ini
+++ b/TraceAnalysis_ini/HOGG/HOGG_FirstStage.ini
@@ -43,7 +43,28 @@ Difference_GMT_to_local_time = 5 % hours
 
 [End]
 
+[Trace]
+	variableName = 'flag_PA_1_1_1'  
+	title = 'Flag: bad data for air pressure sensor' 
+	originalVariable = 'Flag file' 
+	inputFileName = {'flag_PA_1_1_1'} 
+	inputFileName_dates =[datenum(2021,6,1) datenum(2023,12,31)] % expand only if needed
+	measurementType = 'Flags' 
+	units = '' 
+	instrument = ''
+	instrumentSN = ''
+	calibrationDates = ''
+        loggedCalibration = ''
+        currentCalibration = ''
+	comments = '' 
+	minMax = [0,800] 
+	zeroPt = [-9999] 
 
+	plotBottomRight = ''
+	plotBottomLeft  = ''
+	dependent       = 'air_pressure' 
+
+[End]
 
 
 % Air temperature and RH


### PR DESCRIPTION
Clearing out some bad air pressure values so they'll get replaced by the ECCC value