### PR TITLE
Add WD filtering to 2nd stage for Manitoba Sites

### DIFF
--- a/TraceAnalysis_ini/HOGG/HOGG_SecondStage.ini
+++ b/TraceAnalysis_ini/HOGG/HOGG_SecondStage.ini
@@ -16,6 +16,10 @@
 %
 % Jan 15, 2024 (Ted)
 %	- add Evapotranspiration (ET) using LE and Latent_heat_vaporization biomet function
+%
+% Jan 29, 2024 (Ted)
+%	- create WD filter trace "badWD" to use for cleaning out fluxes when wind is disturbed by tower before sonic
+%
 
 Site_name = 'Hogg Marsh'
 SiteID = 'HOGG'
@@ -243,9 +247,21 @@ searchPath = 'auto'
 	minMax = [0,360]
 [End]
 
+[Trace]
+	variableName = 'badWD'
+
+	Evaluate = 'upper = 30; lower = 330; 
+				badWD = find(WD_1_1_1 >= lower | WD_1_1_1 <= upper);' % based on tower orientation from sonic: fluxes should be filtered out
+
+	title = 'wind direction data to be filtered out due to site layout'
+	units = 'm/s' 
+	minMax = [0,360]
+[End]
+
 % ----------------------------------------------------------------------------
 % Turbulent fluxes LI-7200 & LI-7700
 % ----------------------------------------------------------------------------
+
 
 [Trace]
 	variableName = 'CO2'
@@ -284,6 +300,7 @@ searchPath = 'auto'
 	variableName = 'USTAR'
 
 	Evaluate = 'USTAR = shiftMyData(clean_tv,USTAR,datenum(2021,11,07,03,00,0),60);
+				USTAR(badWD)=NaN;
 					USTAR = USTAR;'
 
 	title = 'Friction Velocity'
@@ -295,6 +312,7 @@ searchPath = 'auto'
 	variableName = 'w_ts_cov'
 
 	Evaluate = 'w_ts_cov = shiftMyData(clean_tv,w_ts_cov,datenum(2021,11,07,03,00,0),60);
+				w_ts_cov(badWD)=NaN;
 					w_ts_cov = w_ts_cov;'
 
 	title = 'Covariance of w and sonic temperature (Sonic, after rotation)'
@@ -306,6 +324,7 @@ searchPath = 'auto'
 	variableName = 'w_h2o_cov'
 
 	Evaluate = 'w_h2o_cov = shiftMyData(clean_tv,w_h2o_cov,datenum(2021,11,07,03,00,0),60);
+				w_h2o_cov(badWD)=NaN;
 					w_h2o_cov = w_h2o_cov;'
 
 	title = 'Covariance of w and water vapour mixing ratio (after rotation)'
@@ -317,6 +336,7 @@ searchPath = 'auto'
 	variableName = 'w_co2_cov'
 
 	Evaluate = 'w_co2_cov = shiftMyData(clean_tv,w_co2_cov,datenum(2021,11,07,03,00,0),60);
+				w_co2_cov(badWD)=NaN;
 					w_co2_cov = w_co2_cov;'
 
 	title = 'Covariance of w and CO2 (after rotation)'
@@ -328,6 +348,7 @@ searchPath = 'auto'
 	variableName = 'w_ch4_cov'
 
 	Evaluate = 'w_ch4_cov = shiftMyData(clean_tv,w_ch4_cov,datenum(2021,11,07,03,00,0),60);
+				w_ch4_cov(badWD)=NaN;
 					w_ch4_cov = w_ch4_cov;'
 
 	title = 'Covariance of w and CH4 (after rotation)'
@@ -339,6 +360,7 @@ searchPath = 'auto'
 	variableName = 'LE'
 
 	Evaluate = 'LE = shiftMyData(clean_tv,LE,datenum(2021,11,07,03,00,0),60);
+				LE(badWD)=NaN;
 					LE = LE;'
 
 	title = 'Latent Heat Flux'
@@ -353,6 +375,7 @@ searchPath = 'auto'
 	variableName = 'SLE'
 
 	Evaluate = 'SLE = shiftMyData(clean_tv,SLE,datenum(2021,11,07,03,00,0),60);
+				SLE(badWD)=NaN;
 					SLE = SLE;'
 
 	title = 'Estimate of storage latent heat flux'
@@ -367,6 +390,7 @@ searchPath = 'auto'
 	variableName = 'H'
 
 	Evaluate = 'H = shiftMyData(clean_tv,H,datenum(2021,11,07,03,00,0),60);
+				H(badWD)=NaN;
 					H = H;'
 
 	title = 'sensible heat flux'
@@ -381,6 +405,7 @@ searchPath = 'auto'
 	variableName = 'SH'
 
 	Evaluate = 'SH = shiftMyData(clean_tv,SH,datenum(2021,11,07,03,00,0),60);
+				SH(badWD)=NaN;
 					SH = SH;'
 
 	title = 'Estimate of storage sensible heat flux'
@@ -395,6 +420,7 @@ searchPath = 'auto'
 	variableName = 'FC'
 
 	Evaluate = 'FC = shiftMyData(clean_tv,FC,datenum(2021,11,07,03,00,0),60);
+				FC(badWD)=NaN;
 					FC = FC;'
 	
 	title = 'CO_2 Flux'
@@ -409,6 +435,7 @@ searchPath = 'auto'
 	variableName = 'SC'
 
 	Evaluate = 'SC = shiftMyData(clean_tv,SC,datenum(2021,11,07,03,00,0),60);
+				SC(badWD)=NaN;
 					SC = SC;'
 
 	title = 'Estimate of storage CO2 flux'
@@ -438,6 +465,7 @@ searchPath = 'auto'
 	variableName = 'FCH4'
 
 	Evaluate = 'FCH4 = shiftMyData(clean_tv,FCH4,datenum(2021,11,07,03,00,0),60);
+				FCH4(badWD)=NaN;
 					FCH4 = FCH4;'
 	
 	title = 'CH_4 Flux'
@@ -452,6 +480,7 @@ searchPath = 'auto'
 	variableName = 'SCH4'
 
 	Evaluate = 'SCH4 = shiftMyData(clean_tv,SCH4,datenum(2021,11,07,03,00,0),60);
+				SCH4(badWD)=NaN;
 					SCH4 = SCH4;'
 	
 	title = 'Estimate of storage CH4 flux'
@@ -466,6 +495,7 @@ searchPath = 'auto'
 	variableName = 'TKE'
 
 	Evaluate = 'TKE = shiftMyData(clean_tv,TKE,datenum(2021,11,07,03,00,0),60);
+				TKE(badWD)=NaN;
 					TKE = TKE;'
 
 	title = 'Turbulent kinetic energy'
@@ -533,6 +563,7 @@ searchPath = 'auto'
 	variableName = 'TAU'
 
 	Evaluate = 'TAU = shiftMyData(clean_tv,TAU,datenum(2021,11,07,03,00,0),60);
+				TAU(badWD)=NaN;
 					TAU = TAU;'
 
 	title = 'Corrected momentum flux'

--- a/TraceAnalysis_ini/OHM/OHM_SecondStage.ini
+++ b/TraceAnalysis_ini/OHM/OHM_SecondStage.ini
@@ -18,6 +18,10 @@
 %
 % Jan 18, 2024 (Ted)
 %	- cleanup of lines using calc_avg_trace with single argument
+%
+% Jan 29, 2024 (Ted)
+%	- create WD filter trace "badWD" to use for cleaning out fluxes when wind is disturbed by tower before sonic
+%
 
 Site_name = 'Oak Hammond Marsh'
 SiteID = 'OHM'
@@ -222,6 +226,17 @@ searchPath = 'auto'
 	minMax = [0,360]
 [End]
 
+[Trace]
+	variableName = 'badWD'
+
+	Evaluate = 'upper = 30; lower = 330; 
+				badWD = find(WD_1_1_1 >= lower | WD_1_1_1 <= upper);' % based on tower orientation from sonic: fluxes should be filtered out
+
+	title = 'wind direction data to be filtered out due to site layout'
+	units = 'm/s' 
+	minMax = [0,360]
+[End]
+
 % ----------------------------------------------------------------------------
 % Turbulent fluxes LI-7200 & LI-7700
 % ----------------------------------------------------------------------------
@@ -229,7 +244,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'CO2'
 
-	Evaluate = 'CO2 = CO2;'
+	Evaluate = 'CO2 = shiftMyData(clean_tv,CO2,datenum(2021,11,07,03,00,0),60);
+					CO2 = CO2;'
 
 	title = 'CO2 in mole fraction of wet air'
 	units = '\mu mol / mol wet air'
@@ -239,7 +255,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'H2O'
 
-	Evaluate = 'H2O = H2O;'
+	Evaluate = 'H2O = shiftMyData(clean_tv,H2O,datenum(2021,11,07,03,00,0),60);
+					H2O = H2O;'
 
 	title = 'H2O in mole fraction of wet air'
 	units = 'mm mol / mol wet air'
@@ -249,7 +266,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'CH4'
 
-	Evaluate = 'CH4 = CH4;'
+	Evaluate = 'CH4 = shiftMyData(clean_tv,CH4,datenum(2021,11,07,03,00,0),60);
+					CH4 = CH4;'
 
 	title = 'CH4 in mole fraction of wet air'
 	units = 'nmol / mol wet air'
@@ -259,7 +277,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'USTAR'
 
-	Evaluate = 'USTAR = USTAR;'
+	Evaluate = 'USTAR = shiftMyData(clean_tv,USTAR,datenum(2021,11,07,03,00,0),60);
+				USTAR(badWD)=NaN;
+					USTAR = USTAR;'
 
 	title = 'Friction Velocity'
 	units = 'm/s'
@@ -269,7 +289,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'w_ts_cov'
 
-	Evaluate = 'w_ts_cov = w_ts_cov;'
+	Evaluate = 'w_ts_cov = shiftMyData(clean_tv,w_ts_cov,datenum(2021,11,07,03,00,0),60);
+				w_ts_cov(badWD)=NaN;
+					w_ts_cov = w_ts_cov;'
 
 	title = 'Covariance of w and sonic temperature (Sonic, after rotation)'
 	units = 'm/s degK'
@@ -279,7 +301,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'w_h2o_cov'
 
-	Evaluate = 'w_h2o_cov = w_h2o_cov;'
+	Evaluate = 'w_h2o_cov = shiftMyData(clean_tv,w_h2o_cov,datenum(2021,11,07,03,00,0),60);
+				w_h2o_cov(badWD)=NaN;
+					w_h2o_cov = w_h2o_cov;'
 
 	title = 'Covariance of w and water vapour mixing ratio (after rotation)'
 	units = 'm/s mmol/mol'
@@ -289,7 +313,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'w_co2_cov'
 
-	Evaluate = 'w_co2_cov = w_co2_cov;'
+	Evaluate = 'w_co2_cov = shiftMyData(clean_tv,w_co2_cov,datenum(2021,11,07,03,00,0),60);
+				w_co2_cov(badWD)=NaN;
+					w_co2_cov = w_co2_cov;'
 
 	title = 'Covariance of w and CO2 (after rotation)'
 	units = 'm/s umol/mol'
@@ -299,7 +325,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'w_ch4_cov'
 
-	Evaluate = 'w_ch4_cov = w_ch4_cov;'
+	Evaluate = 'w_ch4_cov = shiftMyData(clean_tv,w_ch4_cov,datenum(2021,11,07,03,00,0),60);
+				w_ch4_cov(badWD)=NaN;
+					w_ch4_cov = w_ch4_cov;'
 
 	title = 'Covariance of w and CH4 (after rotation)'
 	units = 'm/s nmol/mol'
@@ -309,7 +337,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'LE'
 
-	Evaluate = 'LE = LE;'
+	Evaluate = 'LE = shiftMyData(clean_tv,LE,datenum(2021,11,07,03,00,0),60);
+				LE(badWD)=NaN;
+					LE = LE;'
 
 	title = 'Latent Heat Flux'
 	units = 'W m^{-2}'
@@ -322,7 +352,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'SLE'
 
-	Evaluate = 'SLE = SLE;'
+	Evaluate = 'SLE = shiftMyData(clean_tv,SLE,datenum(2021,11,07,03,00,0),60);
+				SLE(badWD)=NaN;
+					SLE = SLE;'
 
 	title = 'Estimate of storage latent heat flux'
 	units = 'W m^{-2}'
@@ -335,7 +367,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'H'
 
-	Evaluate = 'H = H;'
+	Evaluate = 'H = shiftMyData(clean_tv,H,datenum(2021,11,07,03,00,0),60);
+				H(badWD)=NaN;
+					H = H;'
 
 	title = 'sensible heat flux'
 	units = 'W m^{-2}'
@@ -348,7 +382,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'SH'
 
-	Evaluate = 'SH = SH;'
+	Evaluate = 'SH = shiftMyData(clean_tv,SH,datenum(2021,11,07,03,00,0),60);
+				SH(badWD)=NaN;
+					SH = SH;'
 
 	title = 'Estimate of storage sensible heat flux'
 	units = 'W m^{-2}'
@@ -361,7 +397,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'FC'
 
-	Evaluate = 'FC = FC;'
+	Evaluate = 'FC = shiftMyData(clean_tv,FC,datenum(2021,11,07,03,00,0),60);
+				FC(badWD)=NaN;
+					FC = FC;'
 	
 	title = 'CO_2 Flux'
 	units = '\mu mol m^{-2} s^{-1}'
@@ -374,7 +412,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'SC'
 
-	Evaluate = 'SC = SC;'
+	Evaluate = 'SC = shiftMyData(clean_tv,SC,datenum(2021,11,07,03,00,0),60);
+				SC(badWD)=NaN;
+					SC = SC;'
 
 	title = 'Estimate of storage CO2 flux'
 	units = 'umol/m^2/s'
@@ -388,7 +428,9 @@ searchPath = 'auto'
 	variableName = 'NEE'
 
 	Evaluate = 'NEE = sum([FC,SC],2,''omitnan'');
-		    NEE(all(isnan(FC)&isnan(SC),2)) = NaN;'
+		    NEE(all(isnan(FC)&isnan(SC),2)) = NaN;
+			NEE = shiftMyData(clean_tv,NEE,datenum(2021,11,07,03,00,0),60);'
+	
 	title = 'net ecosystem exchange'
 	units = '\mu mol m^{-2} s^{-1}'
 	minMax = [-40,50]
@@ -400,7 +442,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'FCH4'
 
-	Evaluate = 'FCH4 = FCH4;'
+	Evaluate = 'FCH4 = shiftMyData(clean_tv,FCH4,datenum(2021,11,07,03,00,0),60);
+				FCH4(badWD)=NaN;
+					FCH4 = FCH4;'
 	
 	title = 'CH_4 Flux'
 	units = 'nmol m^{-2} s^{-1}'
@@ -413,7 +457,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'SCH4'
 
-	Evaluate = 'SCH4 = SCH4;'
+	Evaluate = 'SCH4 = shiftMyData(clean_tv,SCH4,datenum(2021,11,07,03,00,0),60);
+				SCH4(badWD)=NaN;
+					SCH4 = SCH4;'
 	
 	title = 'Estimate of storage CH4 flux'
 	units = 'nmol m^{-2} s^{-1}'
@@ -426,7 +472,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'TKE'
 
-	Evaluate = 'TKE = TKE;'
+	Evaluate = 'TKE = shiftMyData(clean_tv,TKE,datenum(2021,11,07,03,00,0),60);
+				TKE(badWD)=NaN;
+					TKE = TKE;'
 
 	title = 'Turbulent kinetic energy'
 	units = 'm2 s-2'
@@ -437,6 +485,7 @@ searchPath = 'auto'
     variableName = 'ET'
 
     Evaluate = 'ET = LE./Latent_heat_vaporization(TA_1_1_1); % use biomet helper for L_vap
+                ET = shiftMyData(clean_tv,ET,datenum(2021,11,07,03,00,0),60); %fixes a TZ issue
 				ET = ET*60*30;' % convert units from kg/m^2/s to mm/30min standard unit for EddyPro
 
     title = 'Evapotranspiration flux'
@@ -447,7 +496,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'L'
 
-	Evaluate = 'L = L;'
+	Evaluate = 'L = shiftMyData(clean_tv,L,datenum(2021,11,07,03,00,0),60);
+					L = L;'
 
 	title = 'Monin-Obukhov length'
 	units = 'm'
@@ -457,7 +507,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'U_SIGMA'
 
-	Evaluate = 'U_SIGMA = sqrt(u_var);'
+	Evaluate = 'u_var = shiftMyData(clean_tv,u_var,datenum(2021,11,07,03,00,0),60);
+					U_SIGMA = sqrt(u_var);'
 
 	title = 'Standard deviation of velocity fluctuations'
 	units = 'm s-1'
@@ -467,7 +518,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'V_SIGMA'
 
-	Evaluate = 'V_SIGMA = sqrt(v_var);'
+	Evaluate = 'v_var = shiftMyData(clean_tv,v_var,datenum(2021,11,07,03,00,0),60);
+					V_SIGMA = sqrt(v_var);'
 
 	title = 'Standard deviation of lateral velocity fluctuations'
 	units = 'm s-1'
@@ -477,7 +529,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'W_SIGMA'
 
-	Evaluate = 'W_SIGMA = sqrt(w_var);'
+	Evaluate = 'w_var = shiftMyData(clean_tv,w_var,datenum(2021,11,07,03,00,0),60);
+					W_SIGMA = sqrt(w_var);'
 
 	title = 'Standard deviation of vertical velocity fluctuations'
 	units = 'm s-1'
@@ -487,7 +540,9 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'TAU'
 
-	Evaluate = 'TAU = TAU;'
+	Evaluate = 'TAU = shiftMyData(clean_tv,TAU,datenum(2021,11,07,03,00,0),60);
+				TAU(badWD)=NaN;
+					TAU = TAU;'
 
 	title = 'Corrected momentum flux'
 	units = 'kg m-1 s-2'
@@ -497,7 +552,8 @@ searchPath = 'auto'
 [Trace]
 	variableName = 'zdL'
 
-	Evaluate = 'zdL = zdL;'
+	Evaluate = 'zdL = shiftMyData(clean_tv,zdL,datenum(2021,11,07,03,00,0),60);
+					zdL = zdL;'
 
 	title = 'Monin-Obukhov stability parameter. EddyPro output name: (z-d)/L'
 	units = 'dimensionless'

--- a/TraceAnalysis_ini/YOUNG/YOUNG_SecondStage.ini
+++ b/TraceAnalysis_ini/YOUNG/YOUNG_SecondStage.ini
@@ -22,6 +22,10 @@
 %
 % Jan 18, 2024 (Ted)
 %	- cleanup of lines using calc_avg_trace with single argument
+%
+% Jan 29, 2024 (Ted)
+%	- create WD filter trace "badWD" to use for cleaning out fluxes when wind is disturbed by tower before sonic
+%
 
 Site_name = 'Young Marsh'
 SiteID = 'YOUNG'
@@ -247,6 +251,18 @@ searchPath = 'auto'
 	minMax = [0,360]
 [End]
 
+[Trace]
+	variableName = 'badWD'
+
+	Evaluate = 'upper = 30; lower = 330; 
+				badWD = find(WD_1_1_1 >= lower | WD_1_1_1 <= upper);' % based on tower orientation from sonic: fluxes should be filtered out
+
+	title = 'wind direction data to be filtered out due to site layout'
+	units = 'm/s' 
+	minMax = [0,360]
+[End]
+
+
 
 % ----------------------------------------------------------------------------
 % Turbulent fluxes LI-7200 & LI-7700
@@ -289,6 +305,7 @@ searchPath = 'auto'
 	variableName = 'USTAR'
 
 	Evaluate = 'USTAR = shiftMyData(clean_tv,USTAR,datenum(2021,11,07,03,00,0),60);
+				USTAR(badWD)=NaN;
 					USTAR = USTAR;'
 
 	title = 'Friction Velocity'
@@ -300,6 +317,7 @@ searchPath = 'auto'
 	variableName = 'w_ts_cov'
 
 	Evaluate = 'w_ts_cov = shiftMyData(clean_tv,w_ts_cov,datenum(2021,11,07,03,00,0),60);
+				w_ts_cov(badWD)=NaN;
 					w_ts_cov = w_ts_cov;'
 
 	title = 'Covariance of w and sonic temperature (Sonic, after rotation)'
@@ -311,6 +329,7 @@ searchPath = 'auto'
 	variableName = 'w_h2o_cov'
 
 	Evaluate = 'w_h2o_cov = shiftMyData(clean_tv,w_h2o_cov,datenum(2021,11,07,03,00,0),60);
+				w_h2o_cov(badWD)=NaN;
 					w_h2o_cov = w_h2o_cov;'
 
 	title = 'Covariance of w and water vapour mixing ratio (after rotation)'
@@ -322,6 +341,7 @@ searchPath = 'auto'
 	variableName = 'w_co2_cov'
 
 	Evaluate = 'w_co2_cov = shiftMyData(clean_tv,w_co2_cov,datenum(2021,11,07,03,00,0),60);
+				w_co2_cov(badWD)=NaN;
 					w_co2_cov = w_co2_cov;'
 
 	title = 'Covariance of w and CO2 (after rotation)'
@@ -333,6 +353,7 @@ searchPath = 'auto'
 	variableName = 'w_ch4_cov'
 
 	Evaluate = 'w_ch4_cov = shiftMyData(clean_tv,w_ch4_cov,datenum(2021,11,07,03,00,0),60);
+				w_ch4_cov(badWD)=NaN;
 					w_ch4_cov = w_ch4_cov;'
 
 	title = 'Covariance of w and CH4 (after rotation)'
@@ -344,6 +365,7 @@ searchPath = 'auto'
 	variableName = 'LE'
 
 	Evaluate = 'LE = shiftMyData(clean_tv,LE,datenum(2021,11,07,03,00,0),60);
+				LE(badWD)=NaN;
 					LE = LE;'
 
 	title = 'Latent Heat Flux'
@@ -358,6 +380,7 @@ searchPath = 'auto'
 	variableName = 'SLE'
 
 	Evaluate = 'SLE = shiftMyData(clean_tv,SLE,datenum(2021,11,07,03,00,0),60);
+				SLE(badWD)=NaN;
 					SLE = SLE;'
 
 	title = 'Estimate of storage latent heat flux'
@@ -372,6 +395,7 @@ searchPath = 'auto'
 	variableName = 'H'
 
 	Evaluate = 'H = shiftMyData(clean_tv,H,datenum(2021,11,07,03,00,0),60);
+				H(badWD)=NaN;
 					H = H;'
 
 	title = 'sensible heat flux'
@@ -386,6 +410,7 @@ searchPath = 'auto'
 	variableName = 'SH'
 
 	Evaluate = 'SH = shiftMyData(clean_tv,SH,datenum(2021,11,07,03,00,0),60);
+				SH(badWD)=NaN;
 					SH = SH;'
 
 	title = 'Estimate of storage sensible heat flux'
@@ -400,6 +425,7 @@ searchPath = 'auto'
 	variableName = 'FC'
 
 	Evaluate = 'FC = shiftMyData(clean_tv,FC,datenum(2021,11,07,03,00,0),60);
+				FC(badWD)=NaN;
 					FC = FC;'
 	
 	title = 'CO_2 Flux'
@@ -414,6 +440,7 @@ searchPath = 'auto'
 	variableName = 'SC'
 
 	Evaluate = 'SC = shiftMyData(clean_tv,SC,datenum(2021,11,07,03,00,0),60);
+				SC(badWD)=NaN;
 					SC = SC;'
 
 	title = 'Estimate of storage CO2 flux'
@@ -443,6 +470,7 @@ searchPath = 'auto'
 	variableName = 'FCH4'
 
 	Evaluate = 'FCH4 = shiftMyData(clean_tv,FCH4,datenum(2021,11,07,03,00,0),60);
+				FCH4(badWD)=NaN;
 					FCH4 = FCH4;'
 	
 	title = 'CH_4 Flux'
@@ -457,6 +485,7 @@ searchPath = 'auto'
 	variableName = 'SCH4'
 
 	Evaluate = 'SCH4 = shiftMyData(clean_tv,SCH4,datenum(2021,11,07,03,00,0),60);
+				SCH4(badWD)=NaN;
 					SCH4 = SCH4;'
 	
 	title = 'Estimate of storage CH4 flux'
@@ -471,6 +500,7 @@ searchPath = 'auto'
 	variableName = 'TKE'
 
 	Evaluate = 'TKE = shiftMyData(clean_tv,TKE,datenum(2021,11,07,03,00,0),60);
+				TKE(badWD)=NaN;
 					TKE = TKE;'
 
 	title = 'Turbulent kinetic energy'
@@ -538,6 +568,7 @@ searchPath = 'auto'
 	variableName = 'TAU'
 
 	Evaluate = 'TAU = shiftMyData(clean_tv,TAU,datenum(2021,11,07,03,00,0),60);
+				TAU(badWD)=NaN;
 					TAU = TAU;'
 
 	title = 'Corrected momentum flux'


### PR DESCRIPTION
Adds a trace in Stage 2 called badWD that finds the index values for when WD_1_1_1 was between 330 - 30 for Hogg, Young, and OHM. Then, I use those index values to set the associated turbulent flux values to NaN. I've run this locally and also compared what I get locally vs what is on the server. More gaps are created as expected.

Note, I didn't make this super flexible to take in a parameter for the tower orientation since we plan to use this for cleaning past data but will use EddyPro wind filtering moving forward.

LMK what you think!