### PR TITLE
New include files for standardizing first stage

### DIFF
--- a/TraceAnalysis_ini/EddyPro_Common_FirstStage_include.ini
+++ b/TraceAnalysis_ini/EddyPro_Common_FirstStage_include.ini
@@ -1,0 +1,1697 @@
+% This is to be included in Site_FistStage.ini files for sites using EddyPro
+
+% Traces common to EddyPro output
+% --> Traces listed in EddyPro file output order
+
+% Questions:
+%--> Should we also include the air_temperature trace?
+%--> What is the difference between air_pressure and air_p_mean?
+%--> Should we use spikes_hf_var or var_spikes for diagnostic purposes. Seems redundant to have both.
+%--> Create dependencies based on spikes_hf_var and skewness_kurtosis_hf_var?
+%--> If there is a standard outlier detection, should it be included here as an Evaluate=''?
+
+[Trace]
+        variableName = 'fakeVariable'
+               title = 'Test to see if a NaN-filled variable is created.'
+    originalVariable = 'Test to see if a NaN-filled variable is created.'
+       inputFileName = {'fakeVariable'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [-9999]
+	
+           dependent = ''
+[End]
+
+[Trace]
+        variableName = 'daytime'
+               title = 'daytime index (1=True, 0=False)'
+    originalVariable = 'daytime index (1=True, 0=False)'
+       inputFileName = {'daytime'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [-9999]
+	
+           dependent = ''
+[End]
+
+[Trace]
+        variableName = 'file_records'
+               title = 'Number of valid records found in the raw file'
+    originalVariable = 'Number of valid records found in the raw file'
+       inputFileName = {'file_records'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [30000,36100]
+              zeroPt = [-9999]
+	%Evaluate = 'file_records = file_records-10;'  % Testing Evaluate in the FirstStage.ini
+           dependent = 'tag_EC_Anemometer,tag_IRGA,tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'used_records'
+               title = 'Number of valid records used for current the averaging period'
+    originalVariable = 'Number of valid records used for current the averaging period'
+       inputFileName = {'used_records'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = '' % Using a missing sample allowance of 10% in EddyPro
+              %minMax = [30000,36100]
+              minMax = [0,36100]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer,tag_IRGA,tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'TAU'
+               title = 'Corrected momentum flux'
+    originalVariable = 'Corrected momentum flux'
+       inputFileName = {'Tau'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'kg m-1 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2.5,2.5]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'qc_Tau'
+               title = 'Quality flag for momentum flux'
+    originalVariable = 'Quality flag for momentum flux'
+       inputFileName = {'qc_Tau'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = 'Are there any other traces derived from the covariance of w-u'
+              minMax = [0,1]
+              zeroPt = [-9999]
+           dependent = 'TAU,rand_err_Tau'
+[End]
+
+[Trace]
+        variableName = 'rand_err_Tau'
+               title = 'Random error for momentum flux'
+    originalVariable = 'Random error for momentum flux'
+       inputFileName = {'rand_err_Tau'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'kg m-1 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-15,15] % Keep an eye on
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'H'
+               title = 'Corrected sensible heat flux'
+    originalVariable = 'Corrected sensible heat flux'
+       inputFileName = {'H'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'qc_H'
+               title = 'Quality flag for sensible heat flux'
+    originalVariable = 'Quality flag for sensible heat flux'
+       inputFileName = {'qc_H'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = 'Add any trace derived from w-ts covariance to dependents?'
+              minMax = [0,1]
+              zeroPt = [-9999]
+	
+           dependent = 'H,rand_err_H'
+[End]
+
+[Trace]
+        variableName = 'rand_err_H'
+               title = 'Random error for sensible heat flux'
+    originalVariable = 'Random error for sensible heat flux'
+       inputFileName = {'rand_err_H'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'LE'
+               title = 'Corrected latent heat flux'
+    originalVariable = 'Corrected latent heat flux'
+       inputFileName = {'LE'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,650]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'qc_LE'
+               title = 'Quality flag for latent heat flux'
+    originalVariable = 'Quality flag for latent heat flux'
+       inputFileName = {'qc_LE'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = 'Add any trace derived from w-h2o covariance to dependents?'
+              minMax = [0,1]
+              zeroPt = [-9999]
+	
+           dependent = 'LE,rand_err_LE'
+[End]
+
+[Trace]
+        variableName = 'rand_err_LE'
+               title = 'Random error for latent heat flux'
+    originalVariable = 'Random error for latent heat flux'
+       inputFileName = {'rand_err_LE'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'Sonic anemometer & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,650]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'FC'
+               title = 'Corrected CO2 flux'
+    originalVariable = 'Corrected CO2 flux'
+       inputFileName = {'co2_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'qc_co2_flux'
+               title = 'Quality flag CO2 flux'
+    originalVariable = 'Quality flag CO2 flux'
+       inputFileName = {'qc_co2_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = 'Add any trace derived from w-co2 covariance to dependents?'
+              minMax = [0,1]
+              zeroPt = [-9999]
+           dependent = 'FC,rand_err_co2_flux'
+[End]
+
+[Trace]
+        variableName = 'rand_err_co2_flux'
+               title = 'Random error for CO2 flux'
+    originalVariable = 'Random error for CO2 flux'
+       inputFileName = {'rand_err_co2_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'h2o_flux'
+               title = 'Corrected H2O flux'
+    originalVariable = 'Corrected H2O flux'
+       inputFileName = {'h2o_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'qc_h2o_flux'
+               title = 'Quality flag H2O flux'
+    originalVariable = 'Quality flag H2O flux'
+       inputFileName = {'qc_h2o_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+              minMax = [0,1]
+              zeroPt = [-9999]
+	          comments = 'Should be redundant with'
+           dependent = 'h2o_flux,rand_err_h2o_flux'
+[End]
+
+[Trace]
+        variableName = 'rand_err_h2o_flux'
+               title = 'Random error for H2O flux'
+    originalVariable = 'Random error for H2O flux'
+       inputFileName = {'rand_err_h2o_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'SH'
+               title = 'Estimate of storage sensible heat flux'
+    originalVariable = 'Estimate of storage sensible heat flux'
+       inputFileName = {'H_strg'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'SLE'
+               title = 'Estimate of storage latent heat flux'
+    originalVariable = 'Estimate of storage latent heat flux'
+       inputFileName = {'LE_strg'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,650]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'SC'
+               title = 'Estimate of storage CO2 flux'
+    originalVariable = 'Estimate of storage CO2 flux'
+       inputFileName = {'co2_strg'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'h2o_strg'
+               title = 'Estimate of storage H2O flux'
+    originalVariable = 'Estimate of storage H2O flux'
+       inputFileName = {'h2o_strg'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'CO2'
+               title = 'CO2 in mole fraction of wet air'
+    originalVariable = 'CO2 in mole fraction of wet air'
+       inputFileName = {'co2_mole_fraction'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '\mu mol / mol wet air'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'Consider bumping max up to 850-900. Overnight values at harvested AB peatland can get up to ~750'
+              minMax = [300,800]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'CO2_MIXING_RATIO'
+               title = 'CO2 in mole fraction of dry air'
+    originalVariable = 'CO2 in mole fraction of dry air'
+       inputFileName = {'co2_mixing_ratio'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '\mu mol / mol dry air'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'Increased max up to 850-900. Overnight values at harvested AB peatland can get up to ~750+'
+              minMax = [320,900]
+              zeroPt = [-9999]
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'co2_time_lag'
+               title = 'Time lag used to synchronize CO2 time series'
+    originalVariable = 'Time lag used to synchronize CO2 time series'
+       inputFileName = {'co2_time_lag'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 's'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'co2_def_timelag'
+               title = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CO2 (1=default, 0=calculated)'
+    originalVariable = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CO2 (1=default, 0=calculated)'
+       inputFileName = {'co2_def_timelag'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'binary'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'H2O'
+               title = 'H2O in mole fraction of wet air'
+    originalVariable = 'CO2 in mole fraction of wet air'
+       inputFileName = {'h2o_mole_fraction'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'mmol / mol wet air'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,35] % Check on generic max value
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'H2O_MIXING_RATIO'
+               title = 'H2O in mole fraction of dry air'
+    originalVariable = 'H2O in mole fraction of dry air'
+       inputFileName = {'h2o_mixing_ratio'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'mmol / mol dry air'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,35]  % Check on generic max value
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'h2o_time_lag'
+               title = 'Time lag used to synchronize H2O time series'
+    originalVariable = 'Time lag used to synchronize H2O time series'
+       inputFileName = {'h2o_time_lag'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 's'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'h2o_def_timelag'
+               title = 'Flag: whether the reported time lag is the default (T) or calculated (F) for H2O (1=default, 0=calculated)'
+    originalVariable = 'Flag: whether the reported time lag is the default (T) or calculated (F) for H2O (1=default, 0=calculated)'
+       inputFileName = {'h2o_def_timelag'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'binary'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'T_SONIC'
+               title = 'Mean temperature of ambient air as measured by the anemometer'
+    originalVariable = 'Mean temperature of ambient air as measured by the anemometer'
+       inputFileName = {'sonic_temperature'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '°C'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1 -273.15 datenum(2000,1,1) datenum(2999,1,1)] 
+            comments = 'EddyPro default unit °K'
+              minMax = [-30,50]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+      variableName = 'PA'
+      title = 'Atmospheric Pressure'
+      originalVariable = 'Atmospheric Pressure'
+      inputFileName = {'air_pressure'}
+      measurementType = 'flux'
+      units = 'Pa'
+      instrument = ''
+      instrumentType = 'IRGA'
+      comments = 'Is the EddyPro default unit Pa?'
+      minMax = [90000,110000]
+      zeroPt = [-9999] 
+      dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'air_density'
+               title = 'Density of ambient air'
+    originalVariable = 'Density of ambient air'
+       inputFileName = {'air_density'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'kg m-3'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0.5,1.5]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'air_heat_capacity'
+               title = 'Specific heat at constant pressure of ambient air'
+    originalVariable = 'Specific heat at constant pressure of ambient air'
+       inputFileName = {'air_heat_capacity'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'J K-1 kg-1'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [950,1050]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'air_molar_volume'
+               title = 'Molar volume of ambient air'
+    originalVariable = 'Molar volume of ambient air'
+       inputFileName = {'air_molar_volume'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm3 mol-1'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0.015,0.04]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'ET'
+               title = 'Evapotranspiration flux'
+    originalVariable = 'Evapotranspiration flux'
+       inputFileName = {'ET'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'mm/hour'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-0.5,2]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'water_vapor_density'
+               title = 'Ambient mass density of water vapor'
+    originalVariable = 'Ambient mass density of water vapor'
+       inputFileName = {'water_vapor_density'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'kg/m3'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,0.03]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'e'
+               title = 'Ambient water vapor partial pressure'
+    originalVariable = 'Ambient water vapor partial pressure'
+       inputFileName = {'e'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'Pa'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,3500]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'es'
+               title = 'Ambient water vapor partial pressure at saturation'
+    originalVariable = 'Ambient water vapor partial pressure at saturation'
+       inputFileName = {'es'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'Pa'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,6000]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'specific_humidity'
+               title = 'Ambient specific humidity on a mass basis'
+    originalVariable = 'Ambient specific humidity on a mass basis'
+       inputFileName = {'specific_humidity'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'kg kg-1'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,0.03]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'RH'  
+	title = 'Relative humidity from EC system' 
+	originalVariable = 'Relative humidity from EC system' 
+	inputFileName = {'RH'} 
+	inputFileName_dates =[] 
+	measurementType = 'flux' 
+	units = '%' 
+	instrument = 'CSAT3 & IRGA'
+	instrumentSN = ''
+	calibrationDates = ''
+        loggedCalibration = '' 
+        currentCalibration = '' 
+	comments = '' 
+	minMax = [0,110]
+	zeroPt = [-9999] 
+[End]
+
+[Trace]
+	variableName = 'VPD'  
+	title = 'Vapour pressure deficit from EC system' 
+	originalVariable = 'Vapour pressure deficit from EC system' 
+	inputFileName = {'VPD'} 
+	inputFileName_dates =[] 
+	measurementType = 'flux' 
+	units = 'Pa' 
+	instrument = 'CSAT3 & IRGA'
+	instrumentSN = ''
+	calibrationDates = ''
+        loggedCalibration = '' 
+        currentCalibration = '' 
+	comments = '' 
+	minMax = [0,4250]
+	zeroPt = [-9999] 
+[End]
+
+[Trace]
+        variableName = 'u_unrot'
+               title = 'Wind component along the u anemometer axis'
+    originalVariable = 'Wind component along the u anemometer axis'
+       inputFileName = {'u_unrot'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-15,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'v_unrot'
+               title = 'Wind component along the v anemometer axis'
+    originalVariable = 'Wind component along the v anemometer axis'
+       inputFileName = {'v_unrot'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-15,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'w_unrot'
+               title = 'Wind component along the w anemometer axis'
+    originalVariable = 'Wind component along the w anemometer axis'
+       inputFileName = {'w_unrot'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'u_rot'
+               title = 'Rotated u wind component (mean wind speed)'
+    originalVariable = 'Rotated u wind component (mean wind speed)'
+       inputFileName = {'u_rot'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,25]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'v_rot'
+               title = 'Rotated v wind component (should be zero)'
+    originalVariable = 'Rotated v wind component (should be zero)'
+       inputFileName = {'u_rot'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-0.001,0.001]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'w_rot'
+               title = 'Rotated w wind component (should be zero)'
+    originalVariable = 'Rotated w wind component (should be zero)'
+       inputFileName = {'u_rot'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-0.001,0.001]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'WS'
+               title = 'Mean wind speed (CSAT3)'
+    originalVariable = 'Mean wind speed (CSAT3)'
+       inputFileName = {'wind_speed'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,20]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+% Added for completeness -- P.Moore (2024-07-15)
+[Trace]
+	      variableName = 'WS_MAX'
+	             title = 'Maximum wind speed (CSAT3)'
+	  originalVariable = 'Maximum wind speed (CSAT3)'
+       inputFileName = {'max_wind_speed'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s' 
+	        instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+	      instrumentSN = ''
+	  calibrationDates = ''
+	          comments = ''
+	            minMax = [0,40]
+[End]
+
+[Trace]
+	variableName = 'wind_dir'
+	title = 'Direction from which the wind blows, with respect to Geographic or Magnetic north'
+	originalVariable = 'Direction from which the wind blows, with respect to Geographic or Magnetic north'
+	inputFileName = {'wind_dir'}
+        inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = '˚'
+	instrument = 'CSAT3'
+  instrumentType = 'Anemometer'
+	instrumentSN = ''
+	calibrationDates = ''
+	comments = ''
+	minMax = [0,360]
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'yaw'
+               title = 'First rotation angle'
+    originalVariable = 'First rotation angle'
+       inputFileName = {'yaw'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '˚'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'pitch'
+               title = 'Second rotation angle'
+    originalVariable = 'Second rotation angle'
+       inputFileName = {'pitch'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '˚'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-30,30]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'USTAR'
+               title = 'Friction velocity'
+    originalVariable = 'Friction velocity'
+       inputFileName = {'us'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = 'Max of 10 seems a bit high. 4 or 5 maybe?'
+              minMax = [0,10]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'TKE'
+               title = 'Turbulent kinetic energy'
+    originalVariable = 'Turbulent kinetic energy'
+       inputFileName = {'TKE'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm2 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'L'
+               title = 'Monin-Obukhov length'
+    originalVariable = 'Monin-Obukhov length'
+       inputFileName = {'L'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-200000,200000]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'zdL'
+               title = 'Monin-Obukhov stability parameter. EddyPro output name: (z-d)/L'
+    originalVariable = 'Monin-Obukhov stability parameter. EddyPro output name: (z-d)/L'
+       inputFileName = {'zdL'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'dimensionless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,50]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'ts'
+               title = 'Scaling temperature'
+    originalVariable = 'Scaling temperature'
+       inputFileName = {'ts'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'K'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-3,2]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'model'
+               title = 'Model for footprint estimation'
+    originalVariable = 'Model for footprint estimation'
+       inputFileName = {'model'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '0=KJ/1=KM/2=HS'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,2]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'x_peak'
+               title = 'Along-wind distance providing the highest (peak) contribution to turbulent fluxes'
+    originalVariable = 'Along-wind distance providing the highest (peak) contribution to turbulent fluxes'
+       inputFileName = {'x_peak'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1000]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'x_offset'
+               title = 'Along-wind distance providing <1% contribution to turbulent fluxes'
+    originalVariable = 'Along-wind distance providing <1% contribution to turbulent fluxes'
+       inputFileName = {'x_offset'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,300]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'x_10p'
+               title = 'Along-wind distance providing 10% (cumulative) contribution to turbulent fluxes'
+    originalVariable = 'Along-wind distance providing 10% (cumulative) contribution to turbulent fluxes'
+       inputFileName = {'x_10p'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1000]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'x_30p'
+               title = 'Along-wind distance providing 30% (cumulative) contribution to turbulent fluxes'
+    originalVariable = 'Along-wind distance providing 30% (cumulative) contribution to turbulent fluxes'
+       inputFileName = {'x_30p'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1500]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'x_50p'
+               title = 'Along-wind distance providing 50% (cumulative) contribution to turbulent fluxes'
+    originalVariable = 'Along-wind distance providing 50% (cumulative) contribution to turbulent fluxes'
+       inputFileName = {'x_50p'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,2000]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'x_70p'
+               title = 'Along-wind distance providing 70% (cumulative) contribution to turbulent fluxes'
+    originalVariable = 'Along-wind distance providing 70% (cumulative) contribution to turbulent fluxes'
+       inputFileName = {'x_70p'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,4000]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'x_90p'
+               title = 'Along-wind distance providing 90% (cumulative) contribution to turbulent fluxes'
+    originalVariable = 'Along-wind distance providing 90% (cumulative) contribution to turbulent fluxes'
+       inputFileName = {'x_90p'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10000]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'un_Tau'
+               title = 'Uncorrected momentum flux'
+    originalVariable = 'Uncorrected momentum flux'
+       inputFileName = {'un_Tau'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'kg m-1 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-15,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'Tau_scf'
+               title = 'Spectral correction factor for momentum flux'
+    originalVariable = 'Spectral correction factor for momentum flux'
+       inputFileName = {'Tau_scf'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,3]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'un_H'
+               title = 'Uncorrected sensible heat flux'
+    originalVariable = 'Uncorrected sensible heat flux'
+       inputFileName = {'un_H'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'H_scf'
+               title = 'Spectral correction factor for sensible heat flux'
+    originalVariable = 'Spectral correction factor for sensible heat flux'
+       inputFileName = {'H_scf'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,4]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'un_LE'
+               title = 'Uncorrected latent heat flux'
+    originalVariable = 'Uncorrected latent heat flux'
+       inputFileName = {'un_LE'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,600]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'LE_scf'
+               title = 'Spectral correction factor for latent heat flux'
+    originalVariable = 'Spectral correction factor for latent heat flux'
+       inputFileName = {'LE_scf'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'un_co2_flux'
+               title = 'Uncorrected CO2 flux'
+    originalVariable = 'Uncorrected CO2 flux'
+       inputFileName = {'un_co2_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'co2_scf'
+               title = 'Spectral correction factor for CO2 flux'
+    originalVariable = 'Spectral correction factor for CO2 flux'
+       inputFileName = {'co2_scf'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'un_h2o_flux'
+               title = 'Uncorrected H2O flux'
+    originalVariable = 'Uncorrected H2O flux'
+       inputFileName = {'un_h2o_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'h2o_scf'
+               title = 'Spectral correction factor for H2O flux'
+    originalVariable = 'Spectral correction factor for H2O flux'
+       inputFileName = {'h2o_scf'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'spikes_hf_u'
+	title = 'Hard flags for u spike test'
+	originalVariable = 'Hard flags for u spike test'
+	inputFileName = {'spikes_hf_2'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'spikes_hf_v'
+	title = 'Hard flags for v spike test'
+	originalVariable = 'Hard flags for v spike test'
+	inputFileName = {'spikes_hf_3'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+[Trace]
+	variableName = 'spikes_hf_w'
+	title = 'Hard flags for w spike test'
+	originalVariable = 'Hard flags for w spike test'
+	inputFileName = {'spikes_hf_4'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'spikes_hf_ts'
+	title = 'Hard flags for ts spike test'
+	originalVariable = 'Hard flags for ts spike test'
+	inputFileName = {'spikes_hf_5'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'spikes_hf_co2'
+	title = 'Hard flags for co2 spike test'
+	originalVariable = 'Hard flags for co2 spike test'
+	inputFileName = {'spikes_hf_6'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'spikes_hf_h2o'
+	title = 'Hard flags for h2o spike test'
+	originalVariable = 'Hard flags for h2o spike test'
+	inputFileName = {'spikes_hf_7'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+
+[Trace]
+	variableName = 'skewness_kurtosis_hf_u'
+	title = 'Hard flags for u skew_kurt test'
+	originalVariable = 'Hard flags for u skew_kurt test'
+	inputFileName = {'skewness_kurtosis_hf_2'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'skewness_kurtosis_hf_v'
+	title = 'Hard flags for v skew_kurt test'
+	originalVariable = 'Hard flags for v skew_kurt test'
+	inputFileName = {'skewness_kurtosis_hf_3'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'skewness_kurtosis_hf_w'
+	title = 'Hard flags for w skew_kurt test'
+	originalVariable = 'Hard flags for w skew_kurt test'
+	inputFileName = {'skewness_kurtosis_hf_4'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'skewness_kurtosis_hf_ts'
+	title = 'Hard flags for ts skew_kurt test'
+	originalVariable = 'Hard flags for ts skew_kurt test'
+	inputFileName = {'skewness_kurtosis_hf_5'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+  dependent = ''
+[End]
+
+[Trace]
+	variableName = 'skewness_kurtosis_hf_co2'
+	title = 'Hard flags for co2 skew_kurt test'
+	originalVariable = 'Hard flags for co2 skew_kurt test'
+	inputFileName = {'skewness_kurtosis_hf_6'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+  dependent = ''
+[End]
+
+[Trace]
+	variableName = 'skewness_kurtosis_hf_h2o'
+	title = 'Hard flags for h2o skew_kurt test'
+	originalVariable = 'Hard flags for h2o skew_kurt test'
+	inputFileName = {'skewness_kurtosis_hf_7'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+  dependent = ''
+[End]
+
+[Trace]
+        variableName = 'u_spikes'
+               title = 'Number of spikes detected and eliminated for u'
+    originalVariable = 'Number of spikes detected and eliminated for u'
+       inputFileName = {'u_spikes'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '#'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360] % Revisit (P.Moore - 2024-07-15)
+              zeroPt = [-9999]
+	
+           %dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'v_spikes'
+               title = 'Number of spikes detected and eliminated for v'
+    originalVariable = 'Number of spikes detected and eliminated for v'
+       inputFileName = {'v_spikes'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360] % Revisit (P.Moore - 2024-07-15)
+              zeroPt = [-9999]
+	
+           %dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'w_spikes'
+               title = 'Number of spikes detected and eliminated for w'
+    originalVariable = 'Number of spikes detected and eliminated for w'
+       inputFileName = {'w_spikes'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360] % Revisit (P.Moore - 2024-07-15)
+              zeroPt = [-9999]
+	
+           %dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'ts_spikes'
+               title = 'Number of spikes detected and eliminated for ts'
+    originalVariable = 'Number of spikes detected and eliminated for ts'
+       inputFileName = {'ts_spikes'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360] % Revisit (P.Moore - 2024-07-15)
+              zeroPt = [-9999]
+           %dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'co2_spikes'
+               title = 'Number of spikes detected and eliminated for co2'
+    originalVariable = 'Number of spikes detected and eliminated for co2'
+       inputFileName = {'co2_spikes'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360] % Revisit (P.Moore - 2024-07-15)
+              zeroPt = [-9999]
+	
+           %dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'h2o_spikes'
+               title = 'Number of spikes detected and eliminated for h2o'
+    originalVariable = 'Number of spikes detected and eliminated for h2o'
+       inputFileName = {'h2o_spikes'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360] % Revisit (P.Moore - 2024-07-15)
+              zeroPt = [-9999]
+	
+           %dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'u_var'
+               title = 'Variance of u'
+    originalVariable = 'Variance of u'
+       inputFileName = {'u_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm2 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-1.0000e-04,25]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'v_var'
+               title = 'Variance of v'
+    originalVariable = 'Variance of v'
+       inputFileName = {'v_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm2 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-1.0000e-04,25]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'w_var'
+               title = 'Variance of w'
+    originalVariable = 'Variance of w'
+       inputFileName = {'w_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-0.01,5]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'ts_var'
+               title = 'Variance of ts'
+    originalVariable = 'Variance of ts'
+       inputFileName = {'ts_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'K^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,16]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'w_ts_cov'
+               title = 'Covariance between w and ts'
+    originalVariable = 'Covariance between w and ts'
+       inputFileName = {'w_ts_cov'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s degK'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'w_co2_cov'
+               title = 'Covariance between w and CO2'
+    originalVariable = 'Covariance between w and CO2'
+       inputFileName = {'w_co2_cov'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s umol/mol'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = 'Are the units standard for this variable in EddyPro regardless of IRGA?'
+              minMax = [-4,4]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'w_h2o_cov'
+               title = 'Covariance between w and H2O'
+    originalVariable = 'Covariance between w and H2O'
+       inputFileName = {'w_h2o_cov'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s mmol/mol'
+          instrument = 'CSAT3 & IRGA'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = 'Are the units standard for this variable in EddyPro regardless of IRGA?'
+              minMax = [-5,15]
+              zeroPt = [-9999]
+[End]

--- a/TraceAnalysis_ini/EddyPro_LI7200_FirstStage_include.ini
+++ b/TraceAnalysis_ini/EddyPro_LI7200_FirstStage_include.ini
@@ -1,0 +1,284 @@
+% This is to be included in Site_FistStage.ini files when an LI-7200 IRGA being used
+
+% LI-7200 specific traces
+% --> Traces listed in EddyPro file output order
+
+
+[Trace]
+        variableName = 'co2_var'
+               title = 'Variance of CO2'
+    originalVariable = 'Variance of CO2'
+       inputFileName = {'co2_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '(\mu mol / mol dry air)^2'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,6000] % Check in more detail
+              zeroPt = [-9999]
+	
+           dependent = ''
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'h2o_var'
+               title = 'Variance of H2O'
+    originalVariable = 'Variance of H2O'
+       inputFileName = {'h2o_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '(mmol / mol dry air)^2'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,3] % Check in more detail
+              zeroPt = [-9999]
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'avg_signal_strength_7200_mean'
+               title = 'Mean value of avg signal strength 7200'
+    originalVariable = 'Mean value of avg signal strength 7200'
+       inputFileName = {'avg_signal_strength_7200_mean'} % Is this a custom variable in EddyPro?
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'What is an appropriate lower value? Should it be higher than LI-7500?'
+              minMax = [80,110]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'co2_signal_strength_7200_mean'
+               title = 'Mean value of co2 signal strength 7200'
+    originalVariable = 'Mean value of co2 signal strength 7200'
+       inputFileName = {'co2_signal_strength_7200_mean'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = '50 seems low. Increase from 50 to 80?'
+              minMax = [50,110]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'h2o_signal_strength_7200_mean'
+               title = 'Mean value of h2o signal strength 7200'
+    originalVariable = 'Mean value of h2o signal strength 7200'
+       inputFileName = {'h2o_signal_strength_7200_mean'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = '50 seems low. Increase from 50 to 80?'
+              minMax = [50,110]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'delta_signal_strength_7200_mean'
+               title = 'Mean value of delta signal strength 7200'
+    originalVariable = 'Mean value of delta signal strength 7200'
+       inputFileName = {'delta_signal_strength_7200_mean'} % Is this a custom variable in EddyPro?
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-3,3]
+              zeroPt = [-9999]
+	
+[End]
+
+[Trace]
+        variableName = 'flowrate_mean'
+               title = 'sampling flow rate of LI-7200'
+    originalVariable = 'sampling flow rate of LI-7200'
+       inputFileName = {'flowrate_mean'} % This is not a common across EddyPro
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'Flow rate below 10L/min means clogged up LI-7200 and data is not good'
+              minMax = [10/60000, 20/60000]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+
+% *******************************************************************************************
+% LI-7200 Diagnostic Variables
+% --> Arbitrarily setting max to 1 minute of data set -- revisit (P.Moore - 2024-07-16)
+% --> Default assumes EC data is collected at 20 Hz
+% *******************************************************************************************
+
+[Trace]
+        variableName = 'chopper_LI_7200'
+               title = 'Chopper temperature is out of range'
+    originalVariable = 'Chopper temperature is out of range'
+       inputFileName = {'chopper_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'detector_LI_7200'
+               title = 'Detector temperature is out of range'
+    originalVariable = 'Detector temperature is out of range'
+       inputFileName = {'detector_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'pll_LI_7200'
+               title = 'Filter wheel out of phase'
+    originalVariable = 'Filter wheel out of phase'
+       inputFileName = {'pll_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'sync_LI_7200'
+               title = 'Sync flag'
+    originalVariable = 'Sync flag'
+       inputFileName = {'sync_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'delta_p_LI_7200'
+               title = 'Differential pressure is out of range'
+    originalVariable = 'Differential pressure is out of range'
+       inputFileName = {'delta_p_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,180]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'head_detect_LI_7200'
+               title = 'Sensor head not detected-connected'
+    originalVariable = 'Sensor head not detected-connected'
+       inputFileName = {'head_detect_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,180]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 't_in_LI_7200'
+               title = 'Flag for thermocouple at head inlet'
+    originalVariable = 'Flag for thermocouple at head inlet'
+       inputFileName = {'t_in_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'Is this critical?'
+              minMax = [0,18000]
+              zeroPt = [-9999]
+	
+           dependent = ''
+[End]
+
+[Trace]
+        variableName = 't_out_LI_7200'
+               title = 'Flag for thermocouple at head outlet'
+    originalVariable = 'Flag for thermocouple at head outlet'
+       inputFileName = {'t_out_LI_7200'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'Is this critical?'
+              minMax = [0,18000]
+              zeroPt = [-9999]
+	
+           dependent = ''
+[End]
+
+
+% Is diagnostic trace aux_in_LI_7200 needed?

--- a/TraceAnalysis_ini/EddyPro_LI7500_FirstStage_include.ini
+++ b/TraceAnalysis_ini/EddyPro_LI7500_FirstStage_include.ini
@@ -1,0 +1,176 @@
+% This is to be included in Site_FistStage.ini files when an LI-7500 IRGA being used
+
+% LI-7500 specific traces
+% --> Traces listed in EddyPro file output order
+
+% Questions:
+%--> Use individual co2 and h2o signal strength or mean? Seems redundant to keep all three.
+
+[Trace]
+        variableName = 'co2_var'
+               title = 'Variance of CO2'
+    originalVariable = 'Variance of CO2'
+       inputFileName = {'co2_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '(mg m^-3)^2'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'Are the units standard for this variable in EddyPro regardless of user input?'
+              minMax = [0,100] % Check in more detail
+              zeroPt = [-9999]
+	
+           dependent = ''
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'h2o_var'
+               title = 'Variance of H2O'
+    originalVariable = 'Variance of H2O'
+       inputFileName = {'h2o_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '(g m^-3)^2'
+          instrument = ''
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = 'Are the units standard for this variable in EddyPro regardless of user input?'
+              minMax = [0,5000] % Could probably reduce to 3000
+              zeroPt = [-9999]
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'avg_signal_strength_7500_mean'
+               title = 'Mean value of avg signal strength 7500'
+    originalVariable = 'Mean value of avg signal strength 7500'
+       inputFileName = {'mean_value_LI_7500'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7500'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [50,110] % Is there a commonly accepted cutoff?
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'co2_signal_strength_7500_mean'
+               title = 'Mean value of co2 signal strength 7500'
+    originalVariable = 'Mean value of co2 signal strength 7500'
+       inputFileName = {'co2_signal_strength_7500_mean'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7500'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [50,110]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'h2o_signal_strength_7500_mean'
+               title = 'Mean value of h2o signal strength 7500'
+    originalVariable = 'Mean value of h2o signal strength 7500'
+       inputFileName = {'h2o_signal_strength_7500_mean'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7500'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [50,110]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+
+% *******************************************************************************************
+% LI-7500 Diagnostic Variables
+% --> Arbitrarily setting max to 1 minute of data set -- revisit (P.Moore - 2024-07-16)
+% --> Default assumes EC data is collected at 20 Hz
+% *******************************************************************************************
+
+[Trace]
+        variableName = 'chopper_LI_7500'
+               title = 'Chopper temperature is out of range'
+    originalVariable = 'Chopper temperature is out of range'
+       inputFileName = {'chopper_LI_7500'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7500'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'detector_LI_7500'
+               title = 'Detector temperature is out of range'
+    originalVariable = 'Detector temperature is out of range'
+       inputFileName = {'detector_LI_7500'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7500'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'pll_LI_7500'
+               title = 'Filter wheel out of phase'
+    originalVariable = 'Filter wheel out of phase'
+       inputFileName = {'pll_LI_7500'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7500'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]
+
+[Trace]
+        variableName = 'sync_LI_7500'
+               title = 'Sync flag'
+    originalVariable = 'Sync flag'
+       inputFileName = {'sync_LI_7500'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7500'
+      instrumentType = 'IRGA'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_IRGA'
+[End]

--- a/TraceAnalysis_ini/EddyPro_LI7700_FirstStage_include.ini
+++ b/TraceAnalysis_ini/EddyPro_LI7700_FirstStage_include.ini
@@ -1,0 +1,511 @@
+% This is to be included in Site_FistStage.ini files when an LI-7700 methane analyzer is being used
+
+% LI-7700 specific traces
+% --> Traces listed in EddyPro file output order
+
+% Questions:
+%--> Should we use spikes_hf_ch4 or ch4_spikes for diagnostic purposes. Seems redundant to have both.
+%--> Create dependencies based on spikes_hf_ch4 and skewness_kurtosis_hf_ch4?
+
+[Trace]
+        variableName = 'FCH4'
+               title = 'Corrected CH4 flux'
+    originalVariable = 'Corrected CH4 flux'
+       inputFileName = {'ch4_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'nmol/m^2/s'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)] % Changed from 2021 to 2000 throughout (P.Moore - 2024_07_16)
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)] 
+            comments = 'Converted units from umol m-2 s-1 to nmol m-2 s-1'
+              minMax = [-200,700]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'qc_ch4_flux'
+               title = 'Quality flag CH4 flux'
+    originalVariable = 'Quality flag CH4 flux'
+       inputFileName = {'qc_ch4_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [-9999]
+	
+           dependent = 'FCH4,rand_err_ch4_flux'
+[End]
+
+[Trace]
+        variableName = 'rand_err_ch4_flux'
+               title = 'Random error for CH4 flux'
+    originalVariable = 'Random error for CH4 flux'
+       inputFileName = {'rand_err_ch4_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'nmol/m^2/s' % CONVERT TO nmol/m2/s
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1 0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)] 
+            comments = 'Converted units from umol m-2 s-1 to nmol m-2 s-1'
+              minMax = [-200,400]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'SCH4'
+               title = 'Estimate of storage CH4 flux'
+    originalVariable = 'Estimate of storage CH4 flux'
+       inputFileName = {'ch4_strg'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'nmol/m^2/s'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)] 
+            comments = 'Converted units from umol m-2 s-1 to nmol m-2 s-1'
+              minMax = [-200,700]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'CH4'
+               title = 'CH4 in mole fraction of wet air'
+    originalVariable = 'CH4 in mole fraction of wet air'
+       inputFileName = {'ch4_mole_fraction'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'nmol / mol wet air'
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)]   
+            comments = 'converted from mumol / mol to nmol / mol'
+              minMax = [1000,5500]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'CH4_MIXING_RATIO'
+               title = 'CH4 in mole fraction of dry air'
+    originalVariable = 'CH4 in mole fraction of dry air'
+       inputFileName = {'ch4_mixing_ratio'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'nmol / mol dry air'
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)] 
+            comments = 'Converted from umol to nmol'
+              minMax = [1000,5500]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'ch4_time_lag'
+               title = 'Time lag used to synchronize CH4 time series'
+    originalVariable = 'Time lag used to synchronize CH4 time series'
+       inputFileName = {'ch4_time_lag'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 's'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'ch4_def_timelag'
+               title = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CH4 (1=default, 0=calculated)'
+    originalVariable = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CH4 (1=default, 0=calculated)'
+       inputFileName = {'ch4_def_timelag'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'binary'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'un_ch4_flux'
+               title = 'Uncorrected CH4 flux'
+    originalVariable = 'Uncorrected CH4 flux'
+       inputFileName = {'un_ch4_flux'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'nmol/m^2/s' % CONVERT TO nmol/m2/s
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)] 
+            comments = 'Converted to nmol/m2/s'
+              minMax = [-200,700]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'spikes_hf_ch4'
+	title = 'Hard flags for ch4 spike test'
+	originalVariable = 'Hard flags for ch4 spike test'
+	inputFileName = {'spikes_hf_8'}
+             inputFileName_dates =[datenum(2021,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+	variableName = 'skewness_kurtosis_hf_ch4'
+	title = 'Hard flags for ch4 skew_kurt test'
+	originalVariable = 'Hard flags for ch4 skew_kurt test'
+	inputFileName = {'skewness_kurtosis_hf_8'}
+             inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)]
+	measurementType = 'flux'
+	units = 'binary'
+	instrument = ''
+  instrumentType = 'EC'
+	instrumentSN = ''
+	comments = '' 
+	minMax = [0,1] 
+	zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'ch4_spikes'
+               title = 'Number of spikes detected and eliminated for ch4'
+    originalVariable = 'Number of spikes detected and eliminated for ch4'
+       inputFileName = {'ch4_spikes'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '#'
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,360] % Revisit (P.Moore - 2024-07-15)
+              zeroPt = [-9999]
+	
+           %dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'ch4_scf'
+               title = 'Spectral correction factor for CH4 flux'
+    originalVariable = 'Spectral correction factor for CH4 flux'
+       inputFileName = {'ch4_scf'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'ch4_var'
+               title = 'Variance of CH4'
+    originalVariable = 'Variance of CH4'
+       inputFileName = {'ch4_var'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = '(nmol mol-1)^2'
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+   loggedCalibration = [1       0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000000 0 datenum(2000,1,1) datenum(2999,1,1)]
+            comments = 'Converted from umol to nmol which is ^2'
+              minMax = [0,3000]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'  % NEED TO ADD air_p_mean_1
+[End]
+
+[Trace]
+        variableName = 'w_ch4_cov'
+               title = 'Covariance between w and CH4'
+    originalVariable = 'Covariance between w and CH4'
+       inputFileName = {'w_ch4_cov'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = 'm/s nmol/mol'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1 0 datenum(2021,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2021,1,1) datenum(2999,1,1)] 
+            comments = 'converted CH4 from mumol / mol to nmol/mol'
+              minMax = [-2.5,2.5]
+              zeroPt = [-9999]
+[End]
+
+[Trace]
+        variableName = 'rssi_77_mean'
+               title = 'Mean value of CH4 signal strength'
+    originalVariable = 'Mean value of CH4 signal strength'
+       inputFileName = {'rssi_77_mean'} % This is an optional custom variable in EddyPro
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [20,110]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+
+% *******************************************************************************************
+% Arbitrarily setting max to 1 minute of data set -- revisit (P.Moore - 2024-07-16)
+% *******************************************************************************************
+
+[Trace]
+        variableName = 'not_read_LI_7700'
+               title = 'Number of records where LI-7700 is not ready'
+    originalVariable = 'Number of records where LI-7700 is not ready'
+       inputFileName = {'not_ready_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'no_signal_LI_7700'
+               title = 'Number of records where there is no signal from the LI-7700'
+    originalVariable = 'Number of records where there is no signal from the LI-7700'
+       inputFileName = {'no_signal_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 're_unlocked_LI_7700'
+               title = '?'
+    originalVariable = ''
+       inputFileName = {'re_unlocked_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,36000]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'bad_temp_LI_7700'
+               title = '?'
+    originalVariable = ''
+       inputFileName = {'bad_temp_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,36000]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'laser_temp_unregulated_LI_7700'
+               title = 'Problem with the LI-7700 laser'
+    originalVariable = 'Problem with the LI-7700 laser'
+       inputFileName = {'laser_temp_unregulated_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'block_temp_unregulated_LI_7700'
+               title = 'Problem with the LI-7700 block heater'
+    originalVariable = 'Problem with the LI-7700 block heater'
+       inputFileName = {'block_temp_unregulated_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'motor_spinning_LI_7700'
+               title = 'Mirror spinning for window cleaning'
+    originalVariable = 'Mirror spinning for window cleaning'
+       inputFileName = {'motor_spinning_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'pump_on_LI_7700'
+               title = 'Wash fluid pump is on for window cleaning'
+    originalVariable = 'Wash fluid pump is on for window cleaning'
+       inputFileName = {'pump_on_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'top_heater_on_LI_7700'
+               title = 'Top mirror of LI-7700 being heated'
+    originalVariable = 'Top mirror of LI-7700 being heated'
+       inputFileName = {'top_heater_on_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = 'Should not negatively affect measurements'
+              minMax = [0,36000]
+              zeroPt = [-9999]
+	
+           dependent = ''
+[End]
+
+[Trace]
+        variableName = 'bottom_heater_on_LI_7700'
+               title = 'Bottom mirror of LI-7700 being heated'
+    originalVariable = 'Bottom mirror of LI-7700 being heated'
+       inputFileName = {'bottom_heater_on_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = 'Should not negatively affect measurements'
+              minMax = [0,36000]
+              zeroPt = [-9999]
+	
+           dependent = ''
+[End]
+
+[Trace]
+        variableName = 'calibrating_LI_7700'
+               title = 'LI-7700 being calibrated'
+    originalVariable = 'LI-7700 being calibrated'
+       inputFileName = {'calibrating_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'motor_failure_LI_7700'
+               title = 'Motor to spin lower mirror not working'
+    originalVariable = 'Motor to spin lower mirror not working'
+       inputFileName = {'motor_failure_LI_7700'}
+ inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)]
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = 'This is likely to cause other issues if washer fluid not cleared from window'
+              minMax = [0,1200]
+              zeroPt = [-9999]
+	
+           dependent = 'tag_LI7700'
+[End]


### PR DESCRIPTION
- The _include.ini files represent standard outputs by EddyPro and are meant to help minimize the amount of manual input needed to generate first stage ini files. 
- EddyPro_Common_FirstStage_include.ini should be used anytime EddyPro software is used for EC data processing, while other EddyPro_instrument_FirstStage_include.ini files are setup dependent. 
- These ini files can be incorporated into first stage ini files using #include filename