### PR TITLE
Update RAD_FirstStage_include.ini

### DIFF
--- a/TraceAnalysis_ini/RAD_FirstStage_include.ini
+++ b/TraceAnalysis_ini/RAD_FirstStage_include.ini
@@ -15,12 +15,13 @@
 	instrumentSN = ''               
 	Evaluate     = 'lat = configYAML.Metadata.lat;
 			long = configYAML.Metadata.long;
+			longW = -long
 			TimeZoneHour = configYAML.Metadata.TimeZoneHour;
-			GMT = clean_tv+(TimeZoneHour/24);
-			global_potential_radiation = potential_radiation(GMT,lat,long);'
+			GMT = clean_tv-(TimeZoneHour/24);
+			global_potential_radiation = potential_radiation(GMT,lat,longW);'
 	loggedCalibration = []
 	currentCalibration = []
-	comments = ''
+	comments = 'Above assumes TimeZoneHour in YAML file is negative west of prime meridian. We need to make sure this is standardized. The function potential_radiation() assumes longitude west of prime is positive.'
 	minMax = [0,1361]
 	zeroPt = [-9999]
 	dependent = ''
@@ -29,124 +30,119 @@
 
 [Trace]
 	variableName = 'SW_IN_1_1_1'  
-	title = 'incoming shortwave radiation by CNR1' 
-	originalVariable = 'incoming shortwave radiation by CNR1' 
+	title = 'incoming shortwave radiation by pyranometer' 
+	originalVariable = 'incoming shortwave radiation by pyranometer' 
 	inputFileName = {} 
-	inputFileName_dates =[] 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-20,1361]
-	clamped_minMax = [0,1361]
 	zeroPt = [-9999]  
 [End]
 
 [Trace]
 	variableName = 'SW_OUT_1_1_1'  
-	title = 'reflected shortwave radiation by CNR1' 
-	originalVariable = 'reflected shortwave radiation by CNR1' 
+	title = 'reflected shortwave radiation by pyranometer' 
+	originalVariable = 'reflected shortwave radiation by pyranometer' 
 	inputFileName = {} 
-	inputFileName_dates =[] 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
-	instrument = 'CNR1'
+	instrument = ''
 	instrumentSN = ''
 	minMax = [-20,500]
-	clamped_minMax = [0,500]
 	zeroPt = [-9999]  
 [End]
 
 [Trace]
 	variableName = 'SW_IN_1_1_1'  
-	title = 'incoming shortwave radiation by CNR1' 
-	originalVariable = 'incoming shortwave radiation by CNR1' 
+	title = 'incoming shortwave radiation by pyranometer' 
+	originalVariable = 'incoming shortwave radiation by pyranometer' 
 	inputFileName = {} 
-	inputFileName_dates =[] 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-20,1361]
-	clamped_minMax = [0,1361]
-	zeroPt = [-9999]  
+	zeroPt = [-9999]
+ 	comments = ''
+ 		% NOTE: Just an arbitrary stand-in for a discussion that needs to be had
+		% Replace SW_IN with global_potential_radiation, may not be best?  Perhaps better to kill it?
+		% HOWEVER, we may not want these NaNs to propagate with a dependency tag
+		% the flagging above is indicative of conditions that would effect PPFD and LW_IN as well
+		% The flagging below could be due to sensor-specific errors that may not propagate
+		%flag = SW_IN_1_1_1>global_potential_radiation;
+		%SW_IN_1_1_1(flag)=global_potential_radiation(flag);
+		% I think the global potential radiation test should be used (elsewhere perhaps) to flag data for user inspection
   	Evaluate = 'dayNight = 10; %Wm2
               flag = SW_OUT_1_1_1>SW_IN_1_1_1 & (global_potential_radiation > dayNight);
               SW_IN_1_1_1(flag)=NaN;
-
-			  % NOTE: Just an arbitrary stand-in for a discussion that needs to be had
-			  % Replace SW_IN with global_potential_radiation, may not be best?  Perhaps better to kill it?
-			  % HOWEVER, we may not want these NaNs to propagate with a dependency tag
-			  % the flagging above is indicative of conditions that would effect PPFD and LW_IN as well
-			  % The flagging below could be due to sensor-specific errors that may not propagate
-			  flag = SW_IN_1_1_1>global_potential_radiation;
-			  SW_IN_1_1_1(flag)=global_potential_radiation(flag);'
 	dependent = 'tag_IN_Rad'
 [End]
 
 [Trace]
 	variableName = 'SW_OUT_1_1_1'  
-	title = 'reflected shortwave radiation by CNR1' 
-	originalVariable = 'reflected shortwave radiation by CNR1' 
+	title = 'reflected shortwave radiation by pyranometer' 
+	originalVariable = 'reflected shortwave radiation by pyranometer' 
 	inputFileName = {} 
-	inputFileName_dates =[] 
-	measurementType = 'met' 
-	units = 'W/m^2' 
-	instrument = 'CNR1'
-	instrumentSN = ''
-	minMax = [-20,500]
-	clamped_minMax = [0,500]
-	zeroPt = [-9999]  
-  Evaluate = 'flag = SW_OUT_1_1_1>global_potential_radiation & (global_potential_radiation > dayNight);
-              SW_OUT_1_1_1(flag)=NaN;
-			  flag = SW_OUT_1_1_1>SW_IN_1_1_1;
-			  SW_OUT_1_1_1(flag)=SW_IN_1_1_1(flag);'
-[End]
-
-[Trace]
-	variableName = 'LW_IN_1_1_1'  
-	title = 'incoming longwave radiation by CNR1' 
-	originalVariable = 'incoming longwave radiation by CNR1' 
-	inputFileName = {} 
-	inputFileName_dates =[] 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
-	minMax = [-10,1000]
-	clamped_minMax = [0,1000]
+	minMax = [-20,500]
+	zeroPt = [-9999]
+ 	comments = 'Is filling with zero a suitable approach? In particular, what if someone changes dayNight threshold?'
+  Evaluate = 'flag = SW_OUT_1_1_1>global_potential_radiation & (global_potential_radiation > dayNight);
+              SW_OUT_1_1_1(flag)=NaN;
+		flag = SW_OUT_1_1_1>global_potential_radiation & (global_potential_radiation < dayNight);
+		SW_OUT_1_1_1(flag) = 0;'
+[End]
+
+[Trace]
+	variableName = 'LW_IN_1_1_1'  
+	title = 'incoming longwave radiation by pyrgeometer' 
+	originalVariable = 'incoming longwave radiation by pyrgeometer' 
+	inputFileName = {} 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	measurementType = 'met' 
+	units = 'W/m^2' 
+	instrument = ''
+	instrumentSN = ''
+	minMax = [50,850]
 	zeroPt = [-9999]  
 	% dependent = 'tag_IN_Rad'
 [End]
 
 [Trace]
 	variableName = 'LW_OUT_1_1_1'  
-	title = 'outgoing longwave radiation by CNR1' 
-	originalVariable = 'outgoing longwave radiation by CNR1' 
+	title = 'outgoing longwave radiation by pyrgeometer' 
+	originalVariable = 'outgoing longwave radiation by pyrgeometer' 
 	inputFileName = {} 
-	inputFileName_dates =[] 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
-	minMax = [-10,1000]
-	clamped_minMax = [0,1000]
+	minMax = [50,850]
 	zeroPt = [-9999]  
 [End]
 
 
 [Trace]
 	variableName = 'NETRAD_1_1_1'  
-	title = 'net radiation by CNR1' 
-	originalVariable = 'net radiation by CNR1' 
+	title = 'net radiation by net or four-component radiometer' 
+	originalVariable = 'net radiation by net or four-component radiometer' 
 	inputFileName = {} 
-	inputFileName_dates = [] 
+	inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
-	units = 'W/m2' % Should be in % though
+	units = 'W/m2'
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-200,1000]
-	clamped_minMax = [0,1000]
 	zeroPt = [-9999]
 	% Evaluate = 'NETRAD_1_1_1 = SW_IN_1_1_1 + LW_IN_1_1_1 - (SW_OUT_1_1_1 + LW_OUT_1_1_1);'
 [End]
@@ -154,16 +150,15 @@
 
 [Trace]
 	variableName = 'ALB_1_1_1'  
-	title = 'albedo by CNR1' 
-	originalVariable = 'albedo by CNR1' 
+	title = 'albedo' 
+	originalVariable = 'albedo' 
 	inputFileName = {} 
-	inputFileName_dates = [] 
+	inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = '%' 
 	instrument = ''
 	instrumentSN = '' 
 	minMax = [-10,110]
-	clamped_minMax = [0,100]
 	zeroPt = [-9999]  
   Evaluate = 'ALB_1_1_1=SW_OUT_1_1_1./SW_IN_1_1_1;'
 [End]
@@ -175,15 +170,14 @@
 	title = 'incoming PAR' 
 	originalVariable = 'incoming PAR' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(2014,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = '\mu mol/m^2/s' 
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-40,3000]
-	clamped_minMax = [0,3000]
 	zeroPt = [-9999]
-	dependent = 'tag_IN_Rad'
+	% dependent = 'tag_IN_Rad' % An issue with the PPFD sensor does not necessarily imply there's a problem with upward facing pyranometer/pyrgeometer.
 [End]
 
 
@@ -192,12 +186,11 @@
 	title = 'reflected PAR' 
 	originalVariable = 'reflected PAR' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(2014,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = '\mu mol/m^2/s'
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-40,1500]
-	clamped_minMax = [0,1500]
 	zeroPt = [-9999]  
 [End]


### PR DESCRIPTION
- Modified 'Evaluate' statement for 'global_potential_radiation' trace due to current sign conventions on time zone and longitude. 
- Simplified 'Evaluate' statements for SW_IN_1_1_1 and SW_OUT_1_1_1 and removed filling missing data with global_potential radiation. 
- Removed clamped_minMax from traces
- Modified minMax limits