### PR TITLE
Reverted to prveious version for now

### DIFF
--- a/TraceAnalysis_ini/RAD_FirstStage_include.ini
+++ b/TraceAnalysis_ini/RAD_FirstStage_include.ini
@@ -15,13 +15,12 @@
 	instrumentSN = ''               
 	Evaluate     = 'lat = configYAML.Metadata.lat;
 			long = configYAML.Metadata.long;
-			longW = -long
 			TimeZoneHour = configYAML.Metadata.TimeZoneHour;
-			GMT = clean_tv-(TimeZoneHour/24);
-			global_potential_radiation = potential_radiation(GMT,lat,longW);'
+			GMT = clean_tv+(TimeZoneHour/24);
+			global_potential_radiation = potential_radiation(GMT,lat,long);'
 	loggedCalibration = []
 	currentCalibration = []
-	comments = 'Above assumes TimeZoneHour in YAML file is negative west of prime meridian. We need to make sure this is standardized. The function potential_radiation() assumes longitude west of prime is positive.'
+	comments = ''
 	minMax = [0,1361]
 	zeroPt = [-9999]
 	dependent = ''
@@ -30,119 +29,124 @@
 
 [Trace]
 	variableName = 'SW_IN_1_1_1'  
-	title = 'incoming shortwave radiation by pyranometer' 
-	originalVariable = 'incoming shortwave radiation by pyranometer' 
+	title = 'incoming shortwave radiation by CNR1' 
+	originalVariable = 'incoming shortwave radiation by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-20,1361]
+	clamped_minMax = [0,1361]
 	zeroPt = [-9999]  
 [End]
 
 [Trace]
 	variableName = 'SW_OUT_1_1_1'  
-	title = 'reflected shortwave radiation by pyranometer' 
-	originalVariable = 'reflected shortwave radiation by pyranometer' 
+	title = 'reflected shortwave radiation by CNR1' 
+	originalVariable = 'reflected shortwave radiation by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
-	instrument = ''
+	instrument = 'CNR1'
 	instrumentSN = ''
 	minMax = [-20,500]
+	clamped_minMax = [0,500]
 	zeroPt = [-9999]  
 [End]
 
 [Trace]
 	variableName = 'SW_IN_1_1_1'  
-	title = 'incoming shortwave radiation by pyranometer' 
-	originalVariable = 'incoming shortwave radiation by pyranometer' 
+	title = 'incoming shortwave radiation by CNR1' 
+	originalVariable = 'incoming shortwave radiation by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-20,1361]
-	zeroPt = [-9999]
- 	comments = ''
- 		% NOTE: Just an arbitrary stand-in for a discussion that needs to be had
-		% Replace SW_IN with global_potential_radiation, may not be best?  Perhaps better to kill it?
-		% HOWEVER, we may not want these NaNs to propagate with a dependency tag
-		% the flagging above is indicative of conditions that would effect PPFD and LW_IN as well
-		% The flagging below could be due to sensor-specific errors that may not propagate
-		%flag = SW_IN_1_1_1>global_potential_radiation;
-		%SW_IN_1_1_1(flag)=global_potential_radiation(flag);
-		% I think the global potential radiation test should be used (elsewhere perhaps) to flag data for user inspection
+	clamped_minMax = [0,1361]
+	zeroPt = [-9999]  
   	Evaluate = 'dayNight = 10; %Wm2
               flag = SW_OUT_1_1_1>SW_IN_1_1_1 & (global_potential_radiation > dayNight);
               SW_IN_1_1_1(flag)=NaN;
+
+			  % NOTE: Just an arbitrary stand-in for a discussion that needs to be had
+			  % Replace SW_IN with global_potential_radiation, may not be best?  Perhaps better to kill it?
+			  % HOWEVER, we may not want these NaNs to propagate with a dependency tag
+			  % the flagging above is indicative of conditions that would effect PPFD and LW_IN as well
+			  % The flagging below could be due to sensor-specific errors that may not propagate
+			  flag = SW_IN_1_1_1>global_potential_radiation;
+			  SW_IN_1_1_1(flag)=global_potential_radiation(flag);'
 	dependent = 'tag_IN_Rad'
 [End]
 
 [Trace]
 	variableName = 'SW_OUT_1_1_1'  
-	title = 'reflected shortwave radiation by pyranometer' 
-	originalVariable = 'reflected shortwave radiation by pyranometer' 
+	title = 'reflected shortwave radiation by CNR1' 
+	originalVariable = 'reflected shortwave radiation by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
-	instrument = ''
+	instrument = 'CNR1'
 	instrumentSN = ''
 	minMax = [-20,500]
-	zeroPt = [-9999]
- 	comments = 'Is filling with zero a suitable approach? In particular, what if someone changes dayNight threshold?'
+	clamped_minMax = [0,500]
+	zeroPt = [-9999]  
   Evaluate = 'flag = SW_OUT_1_1_1>global_potential_radiation & (global_potential_radiation > dayNight);
               SW_OUT_1_1_1(flag)=NaN;
-		flag = SW_OUT_1_1_1>global_potential_radiation & (global_potential_radiation < dayNight);
-		SW_OUT_1_1_1(flag) = 0;'
+			  flag = SW_OUT_1_1_1>SW_IN_1_1_1;
+			  SW_OUT_1_1_1(flag)=SW_IN_1_1_1(flag);'
 [End]
 
 [Trace]
 	variableName = 'LW_IN_1_1_1'  
-	title = 'incoming longwave radiation by pyrgeometer' 
-	originalVariable = 'incoming longwave radiation by pyrgeometer' 
+	title = 'incoming longwave radiation by CNR1' 
+	originalVariable = 'incoming longwave radiation by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
-	minMax = [50,850]
+	minMax = [-10,1000]
+	clamped_minMax = [0,1000]
 	zeroPt = [-9999]  
 	% dependent = 'tag_IN_Rad'
 [End]
 
 [Trace]
 	variableName = 'LW_OUT_1_1_1'  
-	title = 'outgoing longwave radiation by pyrgeometer' 
-	originalVariable = 'outgoing longwave radiation by pyrgeometer' 
+	title = 'outgoing longwave radiation by CNR1' 
+	originalVariable = 'outgoing longwave radiation by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[] 
 	measurementType = 'met' 
 	units = 'W/m^2' 
 	instrument = ''
 	instrumentSN = ''
-	minMax = [50,850]
+	minMax = [-10,1000]
+	clamped_minMax = [0,1000]
 	zeroPt = [-9999]  
 [End]
 
 
 [Trace]
 	variableName = 'NETRAD_1_1_1'  
-	title = 'net radiation by net or four-component radiometer' 
-	originalVariable = 'net radiation by net or four-component radiometer' 
+	title = 'net radiation by CNR1' 
+	originalVariable = 'net radiation by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates = [] 
 	measurementType = 'met' 
-	units = 'W/m2'
+	units = 'W/m2' % Should be in % though
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-200,1000]
+	clamped_minMax = [0,1000]
 	zeroPt = [-9999]
 	% Evaluate = 'NETRAD_1_1_1 = SW_IN_1_1_1 + LW_IN_1_1_1 - (SW_OUT_1_1_1 + LW_OUT_1_1_1);'
 [End]
@@ -150,15 +154,16 @@
 
 [Trace]
 	variableName = 'ALB_1_1_1'  
-	title = 'albedo' 
-	originalVariable = 'albedo' 
+	title = 'albedo by CNR1' 
+	originalVariable = 'albedo by CNR1' 
 	inputFileName = {} 
-	inputFileName_dates = [datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates = [] 
 	measurementType = 'met' 
 	units = '%' 
 	instrument = ''
 	instrumentSN = '' 
 	minMax = [-10,110]
+	clamped_minMax = [0,100]
 	zeroPt = [-9999]  
   Evaluate = 'ALB_1_1_1=SW_OUT_1_1_1./SW_IN_1_1_1;'
 [End]
@@ -170,14 +175,15 @@
 	title = 'incoming PAR' 
 	originalVariable = 'incoming PAR' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[datenum(2014,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = '\mu mol/m^2/s' 
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-40,3000]
+	clamped_minMax = [0,3000]
 	zeroPt = [-9999]
-	% dependent = 'tag_IN_Rad' % An issue with the PPFD sensor does not necessarily imply there's a problem with upward facing pyranometer/pyrgeometer.
+	dependent = 'tag_IN_Rad'
 [End]
 
 
@@ -186,11 +192,12 @@
 	title = 'reflected PAR' 
 	originalVariable = 'reflected PAR' 
 	inputFileName = {} 
-	inputFileName_dates =[datenum(1901,1,1) datenum(2999,1,1)] 
+	inputFileName_dates =[datenum(2014,1,1) datenum(2999,1,1)] 
 	measurementType = 'met' 
 	units = '\mu mol/m^2/s'
 	instrument = ''
 	instrumentSN = ''
 	minMax = [-40,1500]
+	clamped_minMax = [0,1500]
 	zeroPt = [-9999]  
 [End]


### PR DESCRIPTION
I have reverted back to the previous version of [RAD_FirstStage_include.ini](https://github.com/CANFLUX/Calculation_Procedures/blob/6af9b0671fe6ec92157ab669e3b5d192accf7e64/TraceAnalysis_ini/RAD_FirstStage_include.ini)

As far as I can see, the BB 1/2 ini files are the only ones that make use of this routine yet so it shouldn't effect anything else?  The updates made in [this commit](https://github.com/CANFLUX/Calculation_Procedures/commit/5a13c138ec86683c801b0f5eb4b51d2bd229b9c2) caused an error in the first stage processing for BB1/2 with the following traceback:

```
Reading first stage ini file: 
   C:\Database\Calculation_Procedures\TraceAnalysis_ini\BB\BB_FirstStage.ini 
   Reading included file: C:\Database\Calculation_Procedures\TraceAnalysis_ini\RAD_FirstStage_include.ini. 
Error in trace #4 on line number: 83!
In file: C:\Database\Calculation_Procedures\TraceAnalysis_ini\RAD_FirstStage_include.ini
  MException with properties:

    identifier: 'MATLAB:m_missing_operator'
       message: 'Invalid expression. Check for missing multiplication operator, missing or unbalanced delimiters, or other syntax error. To construct matrices, use brackets instead of parentheses.'
         cause: {}
         stack: [5×1 struct]
    Correction: []

   Reading included file: C:\Database\Calculation_Procedures\TraceAnalysis_ini\EC_FirstStage_include.ini. 
   140 traces read from the ini file. 
   140 traces that exist in year 2023 are kept for processing.
Cleaning traces ...
```

As a result, clean SW_IN_1_1_1, LW_IN_1_1_1, PPFD_IN_1_1_1, etc. traces were not created for BB  This caused issues down the chain with the EddyPro processing routine which auto-generates biomet.csv files from the Clean/SecondStage data.  I don't have time to sort out the issue, so I've just reverted back to the previous working version for now.  Please confirm a future update to this routine works before pushing to vinimet because otherwise it blocks out some important traces.