### PR TITLE
Js bb updates for amerifulux

### DIFF
--- a/TraceAnalysis_ini/BB/BB_firststage.ini
+++ b/TraceAnalysis_ini/BB/BB_firststage.ini
@@ -62,7 +62,7 @@ globalVars.Trace.air_p_mean.currentCalibration          = [1/1000  0 datenum(201
 	originalVariable = 'clean_tv'
 	inputFileName = {'clean_tv'}
 	inputFileName_dates = []
-	measurementType = 'Flux'
+	measurementType = 'Met'
 	units = ''
 	instrument = ''
     instrumentType = ''
@@ -681,7 +681,7 @@ globalVars.Trace.PPFD_OUT_1_1_1.instrumentSN = 'Q21635'
 	variableName = 'wind_dir'
 	title = 'Direction from which the wind blows, with respect to Geographic or Magnetic north'
 	originalVariable = ''
-	inputFileName = {'wind_dir'}
+	inputFileName = {'../epOutputs_batchRun/wind_dir'}
 	inputFileName_dates = [datenum(2014,1,1) datenum(2999,1,1)]
 	measurementType = 'flux'
 	units = '˚'
@@ -696,7 +696,7 @@ globalVars.Trace.PPFD_OUT_1_1_1.instrumentSN = 'Q21635'
 	variableName = 'WS_MAX'
 	title = 'Maximum wind speed (CSAT3)'
 	originalVariable = 'Maximum wind speed (CSAT3)'
-	inputFileName = {'max_wind_speed'}
+	inputFileName = {'../epOutputs_batchRun/max_wind_speed'}
 	inputFileName_dates = [datenum(2014,1,1) datenum(2999,1,1)]
 	measurementType = 'flux'
 	units = 'm/s' 
@@ -706,18 +706,5 @@ globalVars.Trace.PPFD_OUT_1_1_1.instrumentSN = 'Q21635'
 	zeroPt = [-9999] 
 [End]
 
-% hpbl
 
-; [Trace]
-; 	variableName = 'hpbl'  
-; 	title = 'Estimated Height of Planetary Boundary Layer' 
-; 	originalVariable = 'Estimated Height of Planetary Boundary Layer' 
-; 	inputFileName = {'/NARR/hpbl_interp_spline_2ndOrder'}  
-; 	inputFileName_dates =[datenum(2014,1,1) datenum(2999,1,1)] 
-; 	measurementType = 'met' 
-; 	units = 'm'  
-; 	minMax = [0,3000] 
-; 	zeroPt = [-9999]  
-; [End]
-
-#include EC_FirstStage_include.ini
+#include EP_auto_run_FirstStage_include.ini

--- a/TraceAnalysis_ini/BB2/BB2_FirstStage.ini
+++ b/TraceAnalysis_ini/BB2/BB2_FirstStage.ini
@@ -63,7 +63,7 @@ globalVars.Trace.WTD_1_1_1.currentCalibration           = [1.03 -1.864  datenum(
 	originalVariable = 'clean_tv'
 	inputFileName = {'clean_tv'}
 	inputFileName_dates = []
-	measurementType = 'Flux'
+	measurementType = 'Met'
 	units = ''
 	instrument = ''
     instrumentType = ''
@@ -813,7 +813,7 @@ globalVars.Trace.PPFD_OUT_1_1_1.instrumentSN = 'Q21635'
 	variableName = 'wind_dir'
 	title = 'Direction from which the wind blows, with respect to Geographic or Magnetic north'
 	originalVariable = ''
-	inputFileName = {'wind_dir'}
+	inputFileName = {'../epOutputs_batchRun/wind_dir'}
 	inputFileName_dates = [datenum(2019,1,1) datenum(2999,1,1)]
 	measurementType = 'flux'
 	units = '˚'
@@ -831,7 +831,7 @@ globalVars.Trace.PPFD_OUT_1_1_1.instrumentSN = 'Q21635'
 	variableName = 'WS_MAX'
 	title = 'Maximum wind speed (CSAT3)'
 	originalVariable = 'Maximum wind speed (CSAT3)'
-	inputFileName = {'max_wind_speed'}
+	inputFileName = {'../epOutputs_batchRun/max_wind_speed'}
 	inputFileName_dates = [datenum(2019,1,1) datenum(2999,1,1)]
 	measurementType = 'flux'
 	units = 'm/s' 
@@ -845,4 +845,4 @@ globalVars.Trace.PPFD_OUT_1_1_1.instrumentSN = 'Q21635'
 [End]
 
 
-#include EC_FirstStage_include.ini
+#include EP_auto_run_FirstStage_include.ini

--- a/TraceAnalysis_ini/EP_auto_run_FirstStage_include.ini
+++ b/TraceAnalysis_ini/EP_auto_run_FirstStage_include.ini
@@ -1,0 +1,1541 @@
+% Modified include for EddyPro auto-run outputs
+% Temporary until fully incorporated
+
+[Trace]
+        variableName = 'file_records'
+               title = 'Number of valid records found in the raw file'
+    originalVariable = 'Number of valid records found in the raw file'
+       inputFileName = {'../epOutputs_batchRun/file_records'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = ''
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [30000,36100]
+              zeroPt = [NaN]
+	         dependent = 'tag_EC_Anemometer,tag_LI7200,tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'used_records'
+               title = 'Number of valid records used for current the averaging period'
+    originalVariable = 'Number of valid records used for current the averaging period'
+       inputFileName = {'../epOutputs_batchRun/used_records'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = ''
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = '' % Using a missing sample allowance of 10% in EddyPro
+              %minMax = [30000,36100]
+              minMax = [0,36100]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_EC_Anemometer,tag_LI7200,tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'avg_signal_strength_7200_mean'
+               title = 'Mean value of avg signal strength 7200'
+    originalVariable = 'Mean value of avg signal strength 7200'
+       inputFileName = {'../epOutputs_batchRun/avg_signal_strength_7200_mean'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = 'Could change the threshold from 50 to 80'
+              minMax = [92,110]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_LI7200'
+[End]
+
+
+[Trace]
+        variableName = 'flowrate_mean'
+               title = 'sampling flow rate of LI-7200'
+    originalVariable = 'sampling flow rate of LI-7200'
+       inputFileName = {'../epOutputs_batchRun/flowrate_mean'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7200, MODEL: 7200-102'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = 'Flow rate below 10L/min means clogged up LI-7200 and data is not good'
+              minMax = [10/60000, 20/60000]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_LI7200'
+[End]
+
+[Trace]
+        variableName = 'CO2_MIXING_RATIO'
+               title = 'CO2 in mole fraction of dry air'
+    originalVariable = 'CO2 in mole fraction of dry air'
+       inputFileName = {'../epOutputs_batchRun/co2_mixing_ratio'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = '\mu mol / mol dry air'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [320,800]
+              zeroPt = [NaN]
+           dependent = 'tag_LI7200'
+[End]
+
+[Trace]
+        variableName = 'co2_var'
+               title = 'Variance of CO2'
+    originalVariable = 'Variance of CO2'
+       inputFileName = {'../epOutputs_batchRun/co2_var'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = '(\mu mol / mol dry air)^2'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,5000] % Check in more detail
+              zeroPt = [NaN]
+	
+           dependent = ''
+           dependent = 'tag_LI7200'
+[End]
+
+[Trace]
+        variableName = 'H2O_MIXING_RATIO'
+               title = 'H2O in mole fraction of dry air'
+    originalVariable = 'H2O in mole fraction of dry air'
+       inputFileName = {'../epOutputs_batchRun/h2o_mixing_ratio'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'mmol / mol dry air'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,30]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_LI7200'
+[End]
+
+[Trace]
+        variableName = 'h2o_var'
+               title = 'Variance of H2O'
+    originalVariable = 'Variance of H2O'
+       inputFileName = {'../epOutputs_batchRun/h2o_var'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = '(mmol / mol dry air)^2'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,100]
+              zeroPt = [NaN]
+           dependent = 'tag_LI7200'
+[End]
+
+[Trace]
+      variableName = 'air_p_mean'
+      title = 'Total Pressure (LI-7200)'
+      originalVariable = 'Total Pressure (LI-7200)'
+      inputFileName = {'../epOutputs_batchRun/air_p_mean'}
+      measurementType = 'flux'
+      units = 'kPa'
+      instrument = 'LI-7200'
+      instrumentSN = '72H-0509'
+      currentCalibration = ''
+      outputName = ''
+      minMax = [90,110]
+      zeroPt = [-9999] 
+      dependent = 'tag_LI7200'
+
+[End]
+
+[Trace]
+        variableName = 'rssi_77_mean'
+               title = 'Mean value of CH4 signal strength'
+    originalVariable = 'Mean value of CH4 signal strength'
+       inputFileName = {'../epOutputs_batchRun/rssi_77_mean'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = ''
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+            comments = ''
+              minMax = [20,110]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'CH4_MIXING_RATIO'
+               title = 'CH4 in mole fraction of dry air'
+    originalVariable = 'CH4 in mole fraction of dry air'
+       inputFileName = {'../epOutputs_batchRun/ch4_mixing_ratio'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'nmol / mol dry air'
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)] 
+            comments = 'Converted from umol to nmol'
+              minMax = [1000,5500]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_LI7700'
+[End]
+
+[Trace]
+        variableName = 'ch4_var'
+               title = 'Variance of CH4'
+    originalVariable = 'Variance of CH4'
+       inputFileName = {'../epOutputs_batchRun/ch4_var'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = '(nmol mol-1)^2'
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+   loggedCalibration = [1       0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000000 0 datenum(2000,1,1) datenum(2999,1,1)]
+            comments = 'Converted from umol to nmol which is ^2'
+              minMax = [0,3000]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_LI7700'  % NEED TO ADD air_p_mean_1
+[End]
+
+[Trace]
+        variableName = 'w_unrot'
+               title = 'Wind component along the w anemometer axis'
+    originalVariable = 'Wind component along the w anemometer axis'
+       inputFileName = {'../epOutputs_batchRun/w_unrot'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'w_var'
+               title = 'Variance of u'
+    originalVariable = 'Variance of u'
+       inputFileName = {'../epOutputs_batchRun/w_var'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-0.01,5]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'pitch'
+               title = 'Second rotation angle'
+    originalVariable = 'Second rotation angle'
+       inputFileName = {'../epOutputs_batchRun/pitch'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = '˚'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-30,30]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'T_SONIC'
+               title = 'Mean temperature of ambient air as measured by the anemometer'
+    originalVariable = 'Mean temperature of ambient air as measured by the anemometer'
+       inputFileName = {'../epOutputs_batchRun/sonic_temperature'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'C'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+   loggedCalibration = []
+  currentCalibration = []
+            comments = ''
+              minMax = [-30,50]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'ts_var'
+               title = 'Variance of ts'
+    originalVariable = 'Variance of ts'
+       inputFileName = {'../epOutputs_batchRun/ts_var'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'K^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,16]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'wind_speed'
+               title = 'Mean wind speed (CSAT3)'
+    originalVariable = 'Mean wind speed (CSAT3)'
+       inputFileName = {'../epOutputs_batchRun/wind_speed'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,15]
+              zeroPt = [NaN]
+	
+           dependent = 'tag_EC_Anemometer'
+[End]
+
+[Trace]
+        variableName = 'qc_Tau'
+               title = 'Quality flag for momentum flux'
+    originalVariable = 'Quality flag for momentum flux'
+       inputFileName = {'../epOutputs_batchRun/qc_Tau'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+           dependent = 'TAU,rand_err_Tau'
+[End]
+
+[Trace]
+        variableName = 'qc_H'
+               title = 'Quality flag for sensible heat flux'
+    originalVariable = 'Quality flag for sensible heat flux'
+       inputFileName = {'../epOutputs_batchRun/qc_H'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+           dependent = 'H,rand_err_H'
+[End]
+
+[Trace]
+        variableName = 'qc_LE'
+               title = 'Quality flag for latent heat flux'
+    originalVariable = 'Quality flag for latent heat flux'
+       inputFileName = {'../epOutputs_batchRun/qc_LE'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+           dependent = 'LE,rand_err_LE'
+[End]
+
+[Trace]
+        variableName = 'qc_h2o_flux'
+               title = 'Quality flag H2O flux'
+    originalVariable = 'Quality flag H2O flux'
+       inputFileName = {'../epOutputs_batchRun/qc_h2o_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+           dependent = 'h2o_flux,rand_err_h2o_flux'
+[End]
+
+[Trace]
+        variableName = 'qc_co2_flux'
+               title = 'Quality flag CO2 flux'
+    originalVariable = 'Quality flag CO2 flux'
+       inputFileName = {'../epOutputs_batchRun/qc_co2_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+           dependent = 'FC,rand_err_co2_flux'
+[End]
+
+[Trace]
+        variableName = 'qc_ch4_flux'
+               title = 'Quality flag CH4 flux'
+    originalVariable = 'Quality flag CH4 flux'
+       inputFileName = {'../epOutputs_batchRun/qc_ch4_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+           dependent = 'FCH4,rand_err_ch4_flux'
+[End]
+
+% *******************************************************************************************
+% Eddy covariance traces with no dependants since everything should be clean at this stage
+% *******************************************************************************************
+
+[Trace]
+        variableName = 'CO2'
+               title = 'CO2 in mole fraction of wet air'
+    originalVariable = 'CO2 in mole fraction of wet air'
+       inputFileName = {'../epOutputs_batchRun/co2_mole_fraction'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = '\mu mol / mol wet air'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [300,800]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'CH4'
+               title = 'CH4 in mole fraction of wet air'
+    originalVariable = 'CH4 in mole fraction of wet air'
+       inputFileName = {'../epOutputs_batchRun/ch4_mole_fraction'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'nmol / mol wet air'
+          instrument = 'LI-7700'
+      instrumentType = 'LI7700'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2000,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2000,1,1) datenum(2999,1,1)]   
+            comments = 'converted from mumol / mol to nmol / mol'
+              minMax = [1000,5500]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'co2_time_lag'
+               title = 'Time lag used to synchronize CO2 time series'
+    originalVariable = 'Time lag used to synchronize CO2 time series'
+       inputFileName = {'../epOutputs_batchRun/co2_time_lag'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 's'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'co2_def_timelag'
+               title = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CO2 (1=default, 0=calculated)'
+    originalVariable = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CO2 (1=default, 0=calculated)'
+       inputFileName = {'../epOutputs_batchRun/co2_def_timelag'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'binary'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'ch4_time_lag'
+               title = 'Time lag used to synchronize CH4 time series'
+    originalVariable = 'Time lag used to synchronize CH4 time series'
+       inputFileName = {'../epOutputs_batchRun/ch4_time_lag'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 's'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-1.5,1.5]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'ch4_def_timelag'
+               title = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CH4 (1=default, 0=calculated)'
+    originalVariable = 'Flag: whether the reported time lag is the default (T) or calculated (F) for CH4 (1=default, 0=calculated)'
+       inputFileName = {'../epOutputs_batchRun/ch4_def_timelag'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'binary'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'co2_signal_strength_7200_mean'
+               title = 'Mean value of co2 signal strength 7200'
+    originalVariable = 'Mean value of co2 signal strength 7200'
+       inputFileName = {'../epOutputs_batchRun/co2_signal_strength_7200_mean'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [50,110]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'h2o_signal_strength_7200_mean'
+               title = 'Mean value of h2o signal strength 7200'
+    originalVariable = 'Mean value of h2o signal strength 7200'
+       inputFileName = {'../epOutputs_batchRun/h2o_signal_strength_7200_mean'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [50,110]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'delta_signal_strength_7200_mean'
+               title = 'Mean value of delta signal strength 7200'
+    originalVariable = 'Mean value of delta signal strength 7200'
+       inputFileName = {'../epOutputs_batchRun/delta_signal_strength_7200_mean'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-3,3]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'H2O'
+               title = 'H2O in mole fraction of wet air'
+    originalVariable = 'CO2 in mole fraction of wet air'
+       inputFileName = {'../epOutputs_batchRun/h2o_mole_fraction'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'mm mol / mol wet air'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,30]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'h2o_time_lag'
+               title = 'Time lag used to synchronize H2O time series'
+    originalVariable = 'Time lag used to synchronize H2O time series'
+       inputFileName = {'../epOutputs_batchRun/h2o_time_lag'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 's'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'h2o_def_timelag'
+               title = 'Flag: whether the reported time lag is the default (T) or calculated (F) for H2O (1=default, 0=calculated)'
+    originalVariable = 'Flag: whether the reported time lag is the default (T) or calculated (F) for H2O (1=default, 0=calculated)'
+       inputFileName = {'../epOutputs_batchRun/h2o_def_timelag'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'binary'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'Tau_scf'
+               title = 'Spectral correction factor for momentum flux'
+    originalVariable = 'Spectral correction factor for momentum flux'
+       inputFileName = {'../epOutputs_batchRun/Tau_scf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,3]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'H_scf'
+               title = 'Spectral correction factor for sensible heat flux'
+    originalVariable = 'Spectral correction factor for sensible heat flux'
+       inputFileName = {'../epOutputs_batchRun/H_scf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,4]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'LE_scf'
+               title = 'Spectral correction factor for latent heat flux'
+    originalVariable = 'Spectral correction factor for latent heat flux'
+       inputFileName = {'../epOutputs_batchRun/LE_scf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'co2_scf'
+               title = 'Spectral correction factor for CO2 flux'
+    originalVariable = 'Spectral correction factor for CO2 flux'
+       inputFileName = {'../epOutputs_batchRun/co2_scf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'ch4_scf'
+               title = 'Spectral correction factor for CH4 flux'
+    originalVariable = 'Spectral correction factor for CH4 flux'
+       inputFileName = {'../epOutputs_batchRun/ch4_scf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,15]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'h2o_scf'
+               title = 'Spectral correction factor for H2O flux'
+    originalVariable = 'Spectral correction factor for H2O flux'
+       inputFileName = {'../epOutputs_batchRun/h2o_scf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'unitless'
+          instrument = ''
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'w_ts_cov'
+               title = 'Covariance between w and ts'
+    originalVariable = 'Covariance between w and ts'
+       inputFileName = {'../epOutputs_batchRun/w_ts_cov'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s degK'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'w_h2o_cov'
+               title = 'Covariance between w and H2O'
+    originalVariable = 'Covariance between w and H2O'
+       inputFileName = {'../epOutputs_batchRun/w_h2o_cov'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s mmol/mol'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'w_co2_cov'
+               title = 'Covariance between w and CO2'
+    originalVariable = 'Covariance between w and CO2'
+       inputFileName = {'../epOutputs_batchRun/w_co2_cov'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s umol/mol'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-4,4]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'w_ch4_cov'
+               title = 'Covariance between w and CH4'
+    originalVariable = 'Covariance between w and CH4'
+       inputFileName = {'../epOutputs_batchRun/w_ch4_cov'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s nmol/mol'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1 0 datenum(2021,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2021,1,1) datenum(2999,1,1)] 
+            comments = 'converted CH4 from mumol / mol to nmol/mol'
+              minMax = [-2.5,2.5]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'un_LE'
+               title = 'Uncorrected latent heat flux'
+    originalVariable = 'Uncorrected latent heat flux'
+       inputFileName = {'../epOutputs_batchRun/un_LE'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,600]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'LE'
+               title = 'Corrected latent heat flux'
+    originalVariable = 'Corrected latent heat flux'
+       inputFileName = {'../epOutputs_batchRun/LE'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,600]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'SLE'
+               title = 'Estimate of storage latent heat flux'
+    originalVariable = 'Estimate of storage latent heat flux'
+       inputFileName = {'../epOutputs_batchRun/LE_strg'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,600]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'ET'
+               title = 'Evapotranspiration flux'
+    originalVariable = 'Evapotranspiration flux'
+       inputFileName = {'../epOutputs_batchRun/ET'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'mm/hour'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,2]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'un_h2o_flux'
+               title = 'Uncorrected H2O flux'
+    originalVariable = 'Uncorrected H2O flux'
+       inputFileName = {'../epOutputs_batchRun/un_h2o_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'h2o_flux'
+               title = 'Corrected H2O flux'
+    originalVariable = 'Corrected H2O flux'
+       inputFileName = {'../epOutputs_batchRun/h2o_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'h2o_strg'
+               title = 'Estimate of storage H2O flux'
+    originalVariable = 'Estimate of storage H2O flux'
+       inputFileName = {'../epOutputs_batchRun/h2o_strg'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'un_H'
+               title = 'Uncorrected sensible heat flux'
+    originalVariable = 'Uncorrected sensible heat flux'
+       inputFileName = {'../epOutputs_batchRun/un_H'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'H'
+               title = 'Corrected sensible heat flux'
+    originalVariable = 'Corrected sensible heat flux'
+       inputFileName = {'../epOutputs_batchRun/H'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [NaN]
+	
+[End]
+
+
+[Trace]
+        variableName = 'SH'
+               title = 'Estimate of storage sensible heat flux'
+    originalVariable = 'Estimate of storage sensible heat flux'
+       inputFileName = {'../epOutputs_batchRun/H_strg'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'un_co2_flux'
+               title = 'Uncorrected CO2 flux'
+    originalVariable = 'Uncorrected CO2 flux'
+       inputFileName = {'../epOutputs_batchRun/un_co2_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'FC'
+               title = 'Corrected CO2 flux'
+    originalVariable = 'Corrected CO2 flux'
+       inputFileName = {'../epOutputs_batchRun/co2_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'SC'
+               title = 'Estimate of storage CO2 flux'
+    originalVariable = 'Estimate of storage CO2 flux'
+       inputFileName = {'../epOutputs_batchRun/co2_strg'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'un_ch4_flux'
+               title = 'Uncorrected CH4 flux'
+    originalVariable = 'Uncorrected CH4 flux'
+       inputFileName = {'../epOutputs_batchRun/un_ch4_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'nmol/m^2/s' % CONVERT TO nmol/m2/s
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2021,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2021,1,1) datenum(2999,1,1)] 
+            comments = 'Converted to nmol/m2/s'
+              minMax = [-200,700]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'FCH4'
+               title = 'Corrected CH4 flux'
+    originalVariable = 'Corrected CH4 flux'
+       inputFileName = {'../epOutputs_batchRun/ch4_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'nmol/m^2/s'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2021,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2021,1,1) datenum(2999,1,1)] 
+            comments = 'Converted units from umol m-2 s-1 to nmol m-2 s-1'
+              minMax = [-200,700]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'SCH4'
+               title = 'Estimate of storage CH4 flux'
+    originalVariable = 'Estimate of storage CH4 flux'
+       inputFileName = {'../epOutputs_batchRun/ch4_strg'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'nmol/m^2/s'
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1    0 datenum(2021,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2021,1,1) datenum(2999,1,1)] 
+            comments = 'Converted units from umol m-2 s-1 to nmol m-2 s-1'
+              minMax = [-200,700]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'USTAR'
+               title = 'Friction velocity'
+    originalVariable = 'Friction velocity'
+       inputFileName = {'../epOutputs_batchRun/ustar'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,10]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'TKE'
+               title = 'Turbulent kinetic energy'
+    originalVariable = 'Turbulent kinetic energy'
+       inputFileName = {'../epOutputs_batchRun/TKE'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm2 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,15]
+              zeroPt = [NaN]
+[End]
+
+[Trace]
+        variableName = 'L'
+               title = 'Monin-Obukhov length'
+    originalVariable = 'Monin-Obukhov length'
+       inputFileName = {'../epOutputs_batchRun/L'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-200000,200000]
+              zeroPt = [NaN]
+[End]
+
+[Trace]
+        variableName = 'zdL'
+               title = 'Monin-Obukhov stability parameter. EddyPro output name: (z-d)/L'
+    originalVariable = 'Monin-Obukhov stability parameter. EddyPro output name: (z-d)/L'
+       inputFileName = {'../epOutputs_batchRun/z_d_L'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'dimensionless'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,50]
+              zeroPt = [NaN]
+[End]
+
+[Trace]
+        variableName = 'Tstar'
+               title = 'Scaling temperature'
+    originalVariable = 'Scaling temperature'
+       inputFileName = {'../epOutputs_batchRun/Tstar'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'K'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-3,1]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'u_unrot'
+               title = 'Wind component along the u anemometer axis'
+    originalVariable = 'Wind component along the u anemometer axis'
+       inputFileName = {'../epOutputs_batchRun/u_unrot'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-10,10]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'v_unrot'
+               title = 'Wind component along the v anemometer axis'
+    originalVariable = 'Wind component along the v anemometer axis'
+       inputFileName = {'../epOutputs_batchRun/v_unrot'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm/s'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-10,10]
+              zeroPt = [NaN]
+[End]
+
+[Trace]
+        variableName = 'u_var'
+               title = 'Variance of u'
+    originalVariable = 'Variance of u'
+       inputFileName = {'../epOutputs_batchRun/u_var'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm2 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-1.0000e-04,25]
+              zeroPt = [NaN]
+[End]
+
+[Trace]
+        variableName = 'v_var'
+               title = 'Variance of v'
+    originalVariable = 'Variance of v'
+       inputFileName = {'../epOutputs_batchRun/v_var'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm2 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-1.0000e-04,25]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'model'
+               title = 'Model for footprint estimation'
+    originalVariable = 'Model for footprint estimation'
+       inputFileName = {'../epOutputs_batchRun/model'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = '0=KJ/1=KM/2=HS'
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,2]
+              zeroPt = [NaN]
+	
+[End]
+
+
+[Trace]
+        variableName = 'un_Tau'
+               title = 'Uncorrected momentum flux'
+    originalVariable = 'Uncorrected momentum flux'
+       inputFileName = {'../epOutputs_batchRun/un_Tau'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'kg m-1 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-15,15]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'TAU'
+               title = 'Corrected momentum flux'
+    originalVariable = 'Corrected momentum flux'
+       inputFileName = {'../epOutputs_batchRun/Tau'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'kg m-1 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2.5,2.5]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'rand_err_Tau'
+               title = 'Random error for momentum flux'
+    originalVariable = 'Random error for momentum flux'
+       inputFileName = {'../epOutputs_batchRun/rand_err_Tau'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'kg m-1 s-2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-15,15] % Keep an eye on
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'rand_err_LE'
+               title = 'Random error for latent heat flux'
+    originalVariable = 'Random error for latent heat flux'
+       inputFileName = {'../epOutputs_batchRun/rand_err_LE'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-50,600]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'rand_err_h2o_flux'
+               title = 'Random error for H2O flux'
+    originalVariable = 'Random error for H2O flux'
+       inputFileName = {'../epOutputs_batchRun/rand_err_h2o_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'mmol s-1 m-2'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-2,15]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'rand_err_H'
+               title = 'Random error for sensible heat flux'
+    originalVariable = 'Random error for sensible heat flux'
+       inputFileName = {'../epOutputs_batchRun/rand_err_H'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'W/m^2'
+          instrument = 'CSAT3'
+      instrumentType = 'Anemometer'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-300,800]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'rand_err_co2_flux'
+               title = 'Random error for CO2 flux'
+    originalVariable = 'Random error for CO2 flux'
+       inputFileName = {'../epOutputs_batchRun/rand_err_co2_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'umol/m^2/s'
+          instrument = 'CSAT3 & LI-7200'
+      instrumentType = 'EC'
+        instrumentSN = ''
+            comments = ''
+              minMax = [-60,50]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'rand_err_ch4_flux'
+               title = 'Random error for CH4 flux'
+    originalVariable = 'Random error for CH4 flux'
+       inputFileName = {'../epOutputs_batchRun/rand_err_ch4_flux'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'nmol/m^2/s' % CONVERT TO nmol/m2/s
+          instrument = 'CSAT3 & LI-7700'
+      instrumentType = 'EC'
+        instrumentSN = ''
+   loggedCalibration = [1 0 datenum(2021,1,1) datenum(2999,1,1)]
+  currentCalibration = [1000 0 datenum(2021,1,1) datenum(2999,1,1)] 
+            comments = 'Converted units from umol m-2 s-1 to nmol m-2 s-1'
+              minMax = [-200,400]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'water_vapor_density'
+               title = 'Ambient mass density of water vapor'
+    originalVariable = 'Ambient mass density of water vapor'
+       inputFileName = {'../epOutputs_batchRun/water_vapor_density'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'kg/m3'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'e'
+               title = 'Ambient water vapor partial pressure'
+    originalVariable = 'Ambient water vapor partial pressure'
+       inputFileName = {'../epOutputs_batchRun/e'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'Pa'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,3000]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'es'
+               title = 'Ambient water vapor partial pressure at saturation'
+    originalVariable = 'Ambient water vapor partial pressure at saturation'
+       inputFileName = {'../epOutputs_batchRun/es'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'Pa'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,6000]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'air_density'
+               title = 'Density of ambient air'
+    originalVariable = 'Density of ambient air'
+       inputFileName = {'../epOutputs_batchRun/air_density'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'kg m-3'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0.5,1.5]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'air_heat_capacity'
+               title = 'Specific heat at constant pressure of ambient air'
+    originalVariable = 'Specific heat at constant pressure of ambient air'
+       inputFileName = {'../epOutputs_batchRun/air_heat_capacity'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'J K-1 kg-1'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [950,1050]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'specific_humidity'
+               title = 'Ambient specific humidity on a mass basis'
+    originalVariable = 'Ambient specific humidity on a mass basis'
+       inputFileName = {'../epOutputs_batchRun/specific_humidity'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'kg kg-1'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'air_molar_volume'
+               title = 'Molar volume of ambient air'
+    originalVariable = 'Molar volume of ambient air'
+       inputFileName = {'../epOutputs_batchRun/air_molar_volume'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = 'm3 mol-1'
+          instrument = 'LI-7200'
+      instrumentType = 'LI7200'
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+[End]
+
+[Trace]
+        variableName = 'daytime'
+               title = 'daytime index (1=True, 0=False)'
+    originalVariable = 'daytime index (1=True, 0=False)'
+       inputFileName = {'../epOutputs_batchRun/daytime'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+               units = ''
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+	
+           dependent = ''
+[End]

--- a/TraceAnalysis_ini/EP_auto_run_FirstStage_include.ini
+++ b/TraceAnalysis_ini/EP_auto_run_FirstStage_include.ini
@@ -1536,6 +1536,68 @@
             comments = ''
               minMax = [0,1]
               zeroPt = [NaN]
-	
+           dependent = ''
+[End]
+
+
+% Parse spikes_hf_template
+
+[Trace]
+        variableName = 'spikes_hf'
+               title = 'Spike flag by position'
+    originalVariable = ''
+       inputFileName = {'../epOutputs_batchRun/spikes_hf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+        Evaluate     = 'Spikes_st = string(spikes_hf);
+                        spike_array = NaN(length(spikes_hf),8);
+                        for (i=2:9)
+                          spk_i = cellfun(@(s) s(i:min(end,i)), Spikes_st, "uni",0);
+                          spike_array(:,i-1) = str2double(spk_i);
+                        end'
+               units = ''
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = 'As per the docs, there will b 8 of these 0 1 flags corresponding to 8 variables u v w ts co2 h2o ch4 none
+                        first digit (8) can be ignored, so we go though digits 2-9 to parse'
+              minMax = [0,9]
+              zeroPt = [NaN]
+           dependent = ''
+[End]
+
+[Trace]
+        variableName = 'spikes_hf_u'
+               title = 'Spike flag by position'
+    originalVariable = 'daytime index (1=True, 0=False)'
+       inputFileName = {'../epOutputs_batchRun/spikes_hf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+        Evaluate     = 'spikes_hf_u = spike_array(:,2);'
+               units = ''
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
+           dependent = ''
+[End]
+
+[Trace]
+        variableName = 'spikes_hf_v'
+               title = 'Spike flag by position'
+    originalVariable = 'daytime index (1=True, 0=False)'
+       inputFileName = {'../epOutputs_batchRun/spikes_hf'}
+ inputFileName_dates = []
+     measurementType = 'flux'
+        Evaluate     = 'spikes_hf_v = spike_array(:,3);'
+               units = ''
+          instrument = ''
+      instrumentType = ''
+        instrumentSN = ''
+            comments = ''
+              minMax = [0,1]
+              zeroPt = [NaN]
            dependent = ''
 [End]

--- a/TraceAnalysis_ini/RAD_FirstStage_include.ini
+++ b/TraceAnalysis_ini/RAD_FirstStage_include.ini
@@ -167,7 +167,7 @@
 	instrumentSN = ''
 	minMax = [-40,3000]
 	zeroPt = [-9999]
-	% dependent = 'tag_IN_Rad' % An issue with the PPFD sensor does not necessarily imply there's a problem with upward facing pyranometer/pyrgeometer.
+	% dependent = 'tag_IN_Rad' % An issue with the PPFD sensor does not necessarily imply theres a problem with upward facing pyranometer/pyrgeometer.
 [End]
 
 


### PR DESCRIPTION
For now > I've dumped the EddyPro API outputs to a different database folder (epOutputs_batchRun) so as to not overwrite the contents of the "Flux" folder.  It will be easy enough to overwrite the flux folder with these files down the line, but I've left it for now out of caution.  In the interest of expedience, I've added a temporary include file called EP_auto_run_FirstStage_include.ini to reflect the different path so I can post-process the BB data for ameiflux and also pass it on to Johannes who needs the reprocessed data for a paper he's working on.  It can be deleted once the API outputs are incorporated into the Flux folder and the API processing routine has been integrated into the workflow.

**Side Note** The EddyPro "full output" files from the API processing were dumped to binary database files in the epOutputs_batchRun folder using a Python script called by the API instead of the Matlab routine.  The script does not parse flags (eg., spikes_hf) like the Matlab routine (spikes_hf_1, spikes_hf_2, etc.).  My thinking is that the full output files should be dumped "as is" into the database, and there shouldn't be any intermediary processing occurring in the routine to dump the data (e.g., parsing the spikes) as it is less transparent.  Unless you know the Matlab code base, its not apparent what these variables mean or where they come from since they're not in the eddypro output file.  The spikes do not currently appear to be used in the post processing routine anyway?  So it shouldn't matter for now.  However, maybe they should probably be incorporated at some point?  I've added an example to the bottom of EP_auto_run_FirstStage_include.ini (see line 1543) to show how the spike_hf variable can be parsed into the component flags using an evaluate statement.  This could the be used to define dependencies for when a spike test has failed for a given component and also expanded to any of the other statistical flags output by eddypro if desired.